### PR TITLE
Property tests for pure functions + Embeddings audit

### DIFF
--- a/test/cake/citations_property_test.exs
+++ b/test/cake/citations_property_test.exs
@@ -1,0 +1,149 @@
+defmodule Cake.CitationsPropertyTest do
+  @moduledoc """
+  Property tests for `Cake.Citations.extract/2`.
+
+  Pins the structural invariants of citation extraction against arbitrary
+  text and arbitrary chunk_maps. Example tests live in `citations_test.exs`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Cake.Citations
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp positive_index, do: integer(1..32)
+
+  defp metadata do
+    gen all(
+          id <- string(:alphanumeric, min_length: 1, max_length: 8),
+          label <- string(:alphanumeric, max_length: 16)
+        ) do
+      %{id: id, label: label, extras: %{}, source_ref: nil, preview: ""}
+    end
+  end
+
+  defp chunk_map do
+    gen all(entries <- list_of(tuple({positive_index(), metadata()}), max_length: 8)) do
+      Map.new(entries)
+    end
+  end
+
+  # Generates a string that interleaves random words with `[N]` markers,
+  # where N is drawn from the given index pool to control overlap with
+  # the chunk_map keys.
+  defp text_with_markers(index_pool) do
+    gen all(
+          parts <-
+            list_of(
+              one_of([
+                string(:alphanumeric, max_length: 8),
+                map(member_of(index_pool), fn n -> "[#{n}]" end)
+              ]),
+              max_length: 16
+            )
+        ) do
+      Enum.join(parts, " ")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------------
+
+  property "valid citations are always a subset of chunk_map keys" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      {valid, _hallucinated} = Citations.extract(text, map)
+
+      valid_indices = Enum.map(valid, & &1.index)
+      assert Enum.all?(valid_indices, &Map.has_key?(map, &1))
+    end
+  end
+
+  property "hallucinated indices are disjoint from chunk_map keys" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      {_valid, hallucinated} = Citations.extract(text, map)
+      assert Enum.all?(hallucinated, fn idx -> not Map.has_key?(map, idx) end)
+    end
+  end
+
+  property "valid ∪ hallucinated equals the unique markers in the text" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      {valid, hallucinated} = Citations.extract(text, map)
+
+      returned = Enum.sort(Enum.map(valid, & &1.index) ++ hallucinated)
+
+      from_text =
+        ~r/\[(\d+)\]/
+        |> Regex.scan(text)
+        |> Enum.map(fn [_, n] -> String.to_integer(n) end)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert returned == from_text
+    end
+  end
+
+  property "valid citations are returned in first-appearance order" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      {valid, _} = Citations.extract(text, map)
+
+      first_appearance =
+        ~r/\[(\d+)\]/
+        |> Regex.scan(text)
+        |> Enum.map(fn [_, n] -> String.to_integer(n) end)
+        |> Enum.uniq()
+        |> Enum.filter(&Map.has_key?(map, &1))
+
+      assert Enum.map(valid, & &1.index) == first_appearance
+    end
+  end
+
+  property "extract is deterministic for the same inputs" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      assert Citations.extract(text, map) == Citations.extract(text, map)
+    end
+  end
+
+  property "extract is total — never crashes on arbitrary binary text" do
+    check all(
+            text <- binary(),
+            map <- chunk_map()
+          ) do
+      assert {valid, hallucinated} = Citations.extract(text, map)
+      assert is_list(valid)
+      assert is_list(hallucinated)
+    end
+  end
+
+  property "carrier metadata equals the chunk_map value for that index" do
+    check all(
+            map <- chunk_map(),
+            text <- text_with_markers(Enum.to_list(1..32))
+          ) do
+      {valid, _} = Citations.extract(text, map)
+
+      Enum.each(valid, fn %{index: idx, metadata: md} ->
+        assert md == Map.fetch!(map, idx)
+      end)
+    end
+  end
+end

--- a/test/cake/documents/parsed_document_property_test.exs
+++ b/test/cake/documents/parsed_document_property_test.exs
@@ -1,0 +1,114 @@
+defmodule Cake.Documents.ParsedDocumentPropertyTest do
+  @moduledoc """
+  Property tests for `Cake.Documents.ParsedDocument` changeset sanitization.
+
+  `sanitize_text_fields/1` (defined by `use Cake.Schema`) strips NUL bytes
+  from string fields. These properties pin the invariants against arbitrary
+  unicode input.
+  """
+
+  use Cake.DataCase, async: true
+  use ExUnitProperties
+
+  alias Cake.Documents.ParsedDocument
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  # Strings that may contain interleaved NUL bytes — exactly the input that
+  # exercises the sanitizer's filtering branch.
+  defp string_with_nuls do
+    gen all(parts <- list_of(one_of([string(:utf8, max_length: 8), constant("\0")]), max_length: 16)) do
+      Enum.join(parts)
+    end
+  end
+
+  # All string fields get a non-empty suffix so Ecto's cast doesn't
+  # collapse them to nil via :empty_values — that's upstream of
+  # sanitize_text_fields/1 and not what these properties are testing.
+  @field_suffixes %{
+    source: "src",
+    version: "1.0",
+    package: "pkg",
+    url: "https://example.com",
+    title: "t",
+    language: "l",
+    text: "x"
+  }
+
+  defp valid_attrs do
+    fields =
+      Enum.map(@field_suffixes, fn {field, suffix} ->
+        gen all(prefix <- string_with_nuls()) do
+          {field, prefix <> suffix}
+        end
+      end)
+
+    gen all(values <- fixed_list(fields), core <- boolean()) do
+      Map.new([{:core, core} | values])
+    end
+  end
+
+  defp apply_changes!(attrs) do
+    %ParsedDocument{}
+    |> ParsedDocument.changeset(attrs)
+    |> Ecto.Changeset.apply_changes()
+  end
+
+  # The :string-typed fields of the schema, captured here so the assertions
+  # can iterate over them without re-deriving via reflection.
+  defp string_fields do
+    [:source, :version, :package, :url, :title, :language, :text]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------------
+
+  property "no string field in the applied changeset contains a NUL byte" do
+    check all(attrs <- valid_attrs()) do
+      doc = apply_changes!(attrs)
+
+      Enum.each(string_fields(), fn field ->
+        case Map.get(doc, field) do
+          nil -> :ok
+          value when is_binary(value) -> refute String.contains?(value, "\0")
+        end
+      end)
+    end
+  end
+
+  property "sanitize is idempotent — running the changeset twice yields equal applied values" do
+    check all(attrs <- valid_attrs()) do
+      once = apply_changes!(attrs)
+
+      twice =
+        once
+        |> Map.from_struct()
+        |> Map.drop([:__meta__, :id, :inserted_at, :updated_at, :embedding])
+        |> apply_changes!()
+
+      Enum.each(string_fields(), fn field ->
+        assert Map.get(once, field) == Map.get(twice, field)
+      end)
+    end
+  end
+
+  property "non-NUL characters are preserved (output equals input with NULs removed)" do
+    check all(attrs <- valid_attrs()) do
+      doc = apply_changes!(attrs)
+
+      Enum.each(string_fields(), fn field ->
+        case Map.get(attrs, field) do
+          nil ->
+            :ok
+
+          input when is_binary(input) ->
+            expected = String.replace(input, "\0", "")
+            assert Map.get(doc, field) == expected
+        end
+      end)
+    end
+  end
+end

--- a/test/cake/embeddings_test.exs
+++ b/test/cake/embeddings_test.exs
@@ -1,0 +1,78 @@
+defmodule Cake.EmbeddingsTest do
+  @moduledoc """
+  Audit + minimal coverage for `Cake.Embeddings`.
+
+  ## Audit findings (#110)
+
+  `lib/cake/embeddings.ex` is a 3-line function that:
+
+    1. reads `:openai_key` and `:base_url` from `Application.get_env/2`,
+    2. calls `Req.post/1` against the configured URL, and
+    3. pattern-matches the response into `{:ok, %{usage, input, attrs}}`
+       or one of two `{:error, ...}` shapes.
+
+  There is **no batching, no title prepending, and no token-counting logic**
+  in this repo (despite earlier issue text). The function is an integration
+  boundary; the only meaningfully testable surface here is the
+  transport-error branch, which we exercise below by pointing
+  `:base_url` at an unreachable host.
+
+  Live OpenAI calls are out of scope for unit tests and will be tagged
+  `:integration` per #109.
+
+  ## What this file does NOT test
+
+  - Successful HTTP responses — would require an HTTP stub server
+    (Bypass / Req.Test plug). Deferred until a refactor lets `embed/3`
+    accept request options, or a test harness module is introduced.
+  - The OpenAI response-shape unhappy paths beyond transport failure —
+    same reason.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Cake.Embeddings
+
+  setup do
+    original = Application.get_env(:cake, Cake.Embeddings)
+
+    on_exit(fn ->
+      if original do
+        Application.put_env(:cake, Cake.Embeddings, original)
+      else
+        Application.delete_env(:cake, Cake.Embeddings)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "embed/3 transport error" do
+    test "returns {:error, message} when the configured base_url is unreachable" do
+      # Port 1 is reserved/unused; connections refuse immediately.
+      Application.put_env(:cake, Cake.Embeddings,
+        openai_key: "test-key",
+        base_url: "http://127.0.0.1:1"
+      )
+
+      result = Embeddings.embed(:openai, %{input: "hello"}, "text-embedding-ada-002")
+
+      assert {:error, message} = result
+      assert is_binary(message)
+      assert message =~ "Cake.Embeddings"
+      assert message =~ "Application layer error"
+    end
+  end
+
+  describe "Cake.Embeddings.Behaviour contract" do
+    test "the @callback embed/3 is declared with the documented arity" do
+      callbacks = Cake.Embeddings.Behaviour.behaviour_info(:callbacks)
+      assert {:embed, 3} in callbacks
+    end
+
+    test "Cake.Embeddings implements Cake.Embeddings.Behaviour" do
+      behaviours = Cake.Embeddings.module_info(:attributes)[:behaviour] || []
+      assert Cake.Embeddings.Behaviour in behaviours
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three new property/example test files per #110:

### `test/cake/citations_property_test.exs` (7 properties)
- Valid citations are always a subset of `chunk_map` keys
- Hallucinated indices are disjoint from `chunk_map` keys
- Valid ∪ hallucinated equals the unique `[N]` markers in text
- Valid citations preserve first-appearance order
- `extract/2` is deterministic for the same inputs
- `extract/2` is total — never crashes on arbitrary binary input
- Carrier metadata equals the `chunk_map` value for that index

### `test/cake/documents/parsed_document_property_test.exs` (3 properties)
- No string field in the applied changeset contains a NUL byte
- `sanitize_text_fields/1` is idempotent under reapplication
- Non-NUL characters are preserved as-is (output equals input with NULs removed)

### `test/cake/embeddings_test.exs` (audit + 3 example tests)
Documents the audit conclusion: `Cake.Embeddings` is a 3-line `Req.post` integration boundary with **no batching, title prepending, or token logic** in this repo. The only meaningfully testable surface is the transport-error branch, exercised here by pointing `:base_url` at an unreachable host. Successful-HTTP paths are deferred until either a refactor (accepting Req options) or a Bypass-style harness is added; live OpenAI calls will be tagged `:integration` via #109.

## Notes

- `Cake.Pipelines.detuple_with_logging/3` properties are owned by #108, not duplicated here.
- Citation-extraction property work is owned by this PR; #114 reuses these helpers rather than adding its own.

## Test plan

- [x] `mix test test/cake/citations_property_test.exs test/cake/documents/parsed_document_property_test.exs test/cake/embeddings_test.exs` — 10 properties + 3 tests, 0 failures
- [x] Full suite: `mix test` — 17 properties, 389 tests, 0 failures
- [x] `mix compile --warnings-as-errors --force` — clean
- [x] `mix credo --strict` on the three new files — clean

Closes #110.

Merge order: 4 of 7 in #105. Land after #108.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SLF4u1pajnTMmAT7JYHUW)_