### PR TITLE
Property tests for Cake.Prompt.build/4 and Cake.Responses.process/3

### DIFF
--- a/test/cake/prompt_property_test.exs
+++ b/test/cake/prompt_property_test.exs
@@ -1,0 +1,148 @@
+defmodule Cake.PromptPropertyTest do
+  @moduledoc """
+  Property tests for `Cake.Prompt.build/4`.
+
+  Pins two structural invariants of the assembled prompt:
+
+    1. Every chunk's `format_chunk/1` output appears in the system message
+       with ordering preserved.
+    2. The count of `[N]` markers in the system message equals
+       `length(indexed_chunks)`.
+
+  Example tests live in `prompt_test.exs`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Cake.Prompt
+  alias Cake.Test.ConvoChunk
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp prompt_text do
+    string(:alphanumeric, min_length: 1, max_length: 20)
+  end
+
+  defp scored_chunk do
+    gen all(
+          text <- prompt_text(),
+          score <- float(min: 0.0, max: 1.0)
+        ) do
+      {%ConvoChunk{prompt_text: text}, %{relevance_score: score}}
+    end
+  end
+
+  defp indexed_chunks do
+    gen all(chunks <- list_of(scored_chunk(), min_length: 1, max_length: 8)) do
+      chunks
+      |> Enum.with_index(1)
+      |> Enum.map(fn {sc, idx} -> {idx, sc} end)
+    end
+  end
+
+  defp history do
+    list_of(string(:alphanumeric, min_length: 1, max_length: 16), max_length: 12)
+  end
+
+  defp question do
+    string(:alphanumeric, min_length: 1, max_length: 32)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------------
+
+  defp system_content(messages) do
+    [%{role: "system", content: content} | _] = messages
+    content
+  end
+
+  property "every formatted chunk appears in the system message" do
+    check all(
+            chunks <- indexed_chunks(),
+            q <- question(),
+            h <- history()
+          ) do
+      messages = Prompt.build(chunks, q, h)
+      system = system_content(messages)
+
+      Enum.each(chunks, fn indexed ->
+        assert String.contains?(system, Prompt.format_chunk(indexed))
+      end)
+    end
+  end
+
+  property "formatted chunks appear in indexed order in the system message" do
+    check all(
+            chunks <- indexed_chunks(),
+            q <- question(),
+            h <- history()
+          ) do
+      messages = Prompt.build(chunks, q, h)
+
+      # The system prompt's preamble contains literal "[1], [2]" examples,
+      # so binary-matching against the full system message can return
+      # offsets inside the preamble rather than the data section. Split
+      # on "Context:" so the property scopes to the data block only.
+      data_section =
+        messages
+        |> system_content()
+        |> String.split("Context:", parts: 2)
+        |> List.last()
+
+      offsets =
+        Enum.map(chunks, fn indexed ->
+          formatted = Prompt.format_chunk(indexed)
+          {start, _len} = :binary.match(data_section, formatted)
+          start
+        end)
+
+      assert offsets == Enum.sort(offsets)
+    end
+  end
+
+  property "count of [N] markers in the system message equals length(indexed_chunks)" do
+    check all(
+            chunks <- indexed_chunks(),
+            q <- question(),
+            h <- history()
+          ) do
+      messages = Prompt.build(chunks, q, h)
+      system = system_content(messages)
+
+      # Strip the bracketed-citation guidance text "like [1], [2]" from the
+      # system prompt before counting — those literal example markers are
+      # not data-driven and would otherwise pad the count.
+      data_section = system |> String.split("Context:", parts: 2) |> List.last()
+
+      marker_count =
+        ~r/\[(\d+)\]/
+        |> Regex.scan(data_section)
+        |> length()
+
+      assert marker_count == length(chunks)
+    end
+  end
+
+  property "the user message at the tail equals the question verbatim" do
+    check all(
+            chunks <- indexed_chunks(),
+            q <- question(),
+            h <- history()
+          ) do
+      messages = Prompt.build(chunks, q, h)
+      assert List.last(messages) == %{role: "user", content: q}
+    end
+  end
+
+  property "build/4 with empty indexed_chunks uses the no-context system message" do
+    check all(q <- question(), h <- history()) do
+      messages = Prompt.build([], q, h)
+      system = system_content(messages)
+      assert system =~ "no relevant reference material"
+    end
+  end
+end

--- a/test/cake/responses_property_test.exs
+++ b/test/cake/responses_property_test.exs
@@ -1,0 +1,125 @@
+defmodule Cake.ResponsesPropertyTest do
+  @moduledoc """
+  Property tests for `Cake.Responses.process/3`.
+
+  Pins the totality invariant: for arbitrary binary `raw_text` (including
+  malformed UTF-8, `[N]` markers pointing at hallucinated indices, empty
+  strings, and large inputs) and arbitrary `indexed_chunks`, `process/3`
+  must never crash and must return a well-shaped `%Result{}`.
+
+  This codifies the "fallback on malformed responses" requirement from
+  #114 as a structural invariant rather than a finite list of bad-input
+  examples.
+
+  Example tests live in `responses_test.exs`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Cake.Responses
+  alias Cake.Responses.Result
+  alias Cake.Test.StubChunk
+
+  # ---------------------------------------------------------------------------
+  # Generators
+  # ---------------------------------------------------------------------------
+
+  defp metadata_struct do
+    gen all(
+          id <- string(:alphanumeric, min_length: 1, max_length: 8),
+          label <- string(:alphanumeric, max_length: 16),
+          source_ref <- one_of([constant(nil), string(:alphanumeric, max_length: 32)]),
+          preview <- string(:alphanumeric, max_length: 24)
+        ) do
+      %{id: id, label: label, source_ref: source_ref, preview: preview, extras: %{}}
+    end
+  end
+
+  defp scored_stub do
+    gen all(metadata <- metadata_struct(), score <- float(min: 0.0, max: 1.0)) do
+      {%StubChunk{metadata: metadata}, %{relevance_score: score}}
+    end
+  end
+
+  defp indexed_chunks do
+    gen all(stubs <- list_of(scored_stub(), max_length: 6)) do
+      stubs
+      |> Enum.with_index(1)
+      |> Enum.map(fn {sc, idx} -> {idx, sc} end)
+    end
+  end
+
+  # raw_text generators that exercise the parsing surface:
+  #   - completely arbitrary binary (including invalid UTF-8)
+  #   - text with random `[N]` markers (some valid, some hallucinated)
+  defp raw_text do
+    one_of([
+      binary(),
+      string(:utf8),
+      gen all(
+            parts <-
+              list_of(
+                one_of([
+                  string(:alphanumeric, max_length: 8),
+                  map(integer(0..32), fn n -> "[#{n}]" end)
+                ]),
+                max_length: 16
+              )
+          ) do
+        Enum.join(parts, " ")
+      end
+    ])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------------
+
+  property "process/3 never crashes and always returns a %Result{}" do
+    check all(
+            text <- raw_text(),
+            chunks <- indexed_chunks()
+          ) do
+      result = Responses.process(text, chunks)
+      assert %Result{} = result
+    end
+  end
+
+  property "process/3 result fields have the documented shapes" do
+    check all(
+            text <- raw_text(),
+            chunks <- indexed_chunks()
+          ) do
+      result = Responses.process(text, chunks)
+
+      assert result.raw_text == text
+      assert is_map(result.chunk_map)
+      assert is_list(result.citations)
+      assert is_list(result.warnings)
+      assert is_list(result.actions)
+      assert is_binary(result.final_text)
+    end
+  end
+
+  property "every citation in the result corresponds to a chunk_map entry" do
+    check all(
+            text <- raw_text(),
+            chunks <- indexed_chunks()
+          ) do
+      result = Responses.process(text, chunks)
+
+      Enum.each(result.citations, fn citation ->
+        assert Map.has_key?(result.chunk_map, citation.old_index)
+      end)
+    end
+  end
+
+  property "build_citation_map/1 keys exactly match the indexed_chunks indices" do
+    check all(chunks <- indexed_chunks()) do
+      map = Responses.build_citation_map(chunks)
+      indices = Enum.map(chunks, fn {idx, _} -> idx end)
+      assert Enum.sort(Map.keys(map)) == Enum.sort(indices)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two new property test files per #114, scoped to Responses (Embeddings audit moved to #110):

### `test/cake/prompt_property_test.exs` (5 properties)
- Every formatted chunk appears verbatim in the system message
- Formatted chunks appear in indexed order in the data section (after `Context:`)
- Count of `[N]` markers in the data section equals `length(indexed_chunks)`
- The user message at the tail equals the question verbatim
- `build/4` with empty `indexed_chunks` uses the no-context system message

### `test/cake/responses_property_test.exs` (4 properties)
- `process/3` never crashes for arbitrary binary text + arbitrary `indexed_chunks`
- `process/3` result fields have the documented shapes
- Every citation in the result corresponds to a `chunk_map` entry
- `build_citation_map/1` keys exactly match the `indexed_chunks` indices

The totality invariant codifies the "fallback on malformed responses" line of #114 as a structural property rather than a finite list of bad-input examples. Generators include arbitrary binary (potentially invalid UTF-8), unicode strings, and text with both valid and hallucinated `[N]` markers.

## Notes

- The "ordering preserved" property scopes to the data block (split on `Context:`) because the system prompt's preamble contains literal `[1], [2]` example markers that would otherwise return spurious early matches via `:binary.match/2`.
- Existing example tests in `prompt_test.exs` and `responses_test.exs` already cover the issue's example-based bullets (Prompt at 100% / Responses at 97% per the coverage report). This PR adds only the property layer.
- Citation-extraction property work is owned by #110's `citations_property_test.exs`; this PR reuses `Cake.Test.StubChunk` and `Cake.Test.ConvoChunk` rather than introducing new generators.

## Test plan

- [x] `mix test test/cake/prompt_property_test.exs test/cake/responses_property_test.exs` — 9 properties, 0 failures
- [x] Full suite: `mix test` — 16 properties, 386 tests, 0 failures
- [x] `mix compile --warnings-as-errors --force` — clean
- [x] `mix credo --strict` on the two new files — clean

Closes #114.

Merge order: 5 of 7 in #105. Land after #110.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SLF4u1pajnTMmAT7JYHUW)_