### PR TITLE
Characterization tests for Books schemas, BooksController, ChatLive, SearchLive (partial #112)

### DIFF
--- a/test/cake/books/page_content_test.exs
+++ b/test/cake/books/page_content_test.exs
@@ -1,0 +1,24 @@
+defmodule Cake.Books.PageContentTest do
+  @moduledoc """
+  Smoke tests for the `Cake.Books.PageContent` plain struct. The struct is
+  decoded into by the Rust NIF; full ingest-path coverage is deferred until
+  fixture PDFs and a NIF mocking strategy land (see #112's description).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Cake.Books.PageContent
+
+  describe "%PageContent{}" do
+    test "can be constructed with the documented fields" do
+      page = %PageContent{page_number: 7, text: "hello"}
+
+      assert page.page_number == 7
+      assert page.text == "hello"
+    end
+
+    test "field defaults are nil" do
+      assert %PageContent{page_number: nil, text: nil} == %PageContent{}
+    end
+  end
+end

--- a/test/cake/books/skipped_page_test.exs
+++ b/test/cake/books/skipped_page_test.exs
@@ -1,0 +1,24 @@
+defmodule Cake.Books.SkippedPageTest do
+  @moduledoc """
+  Smoke tests for the `Cake.Books.SkippedPage` plain struct. The struct is
+  decoded into by the Rust NIF; full ingest-path coverage is deferred until
+  fixture PDFs and a NIF mocking strategy land (see #112's description).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Cake.Books.SkippedPage
+
+  describe "%SkippedPage{}" do
+    test "can be constructed with the documented fields" do
+      skipped = %SkippedPage{page_number: 12, reason: "image-only page"}
+
+      assert skipped.page_number == 12
+      assert skipped.reason == "image-only page"
+    end
+
+    test "field defaults are nil" do
+      assert %SkippedPage{page_number: nil, reason: nil} == %SkippedPage{}
+    end
+  end
+end

--- a/test/cake_web/controllers/books_controller_test.exs
+++ b/test/cake_web/controllers/books_controller_test.exs
@@ -1,0 +1,57 @@
+defmodule CakeWeb.BooksControllerTest do
+  @moduledoc """
+  Characterization tests for `CakeWeb.BooksController.download/2`.
+
+  Three branches:
+
+    * The `file_path` segment doesn't match any `ParsedBook` row → 404 with
+      "Book not found".
+    * A row exists but the on-disk file is gone → 404 with
+      "File not found on disk".
+    * Row exists and file is present → 200 with the file body and a
+      Content-Disposition attachment header.
+  """
+
+  use CakeWeb.ConnCase
+
+  import Cake.BooksFixtures
+
+  describe "GET /books/download/*file_path" do
+    test "returns 404 when no ParsedBook matches the requested path", %{conn: conn} do
+      conn = get(conn, ~p"/books/download/no/such/book.pdf")
+
+      assert response(conn, 404) =~ "Book not found"
+    end
+
+    test "returns 404 when the ParsedBook row exists but the file is missing", %{conn: conn} do
+      missing_path = "/tmp/nonexistent-cake-book-#{System.unique_integer([:positive])}.pdf"
+      _book = parsed_book_fixture(%{source_file_path: missing_path})
+
+      conn = get(conn, ~p"/books/download/#{missing_path}")
+
+      assert response(conn, 404) =~ "File not found on disk"
+    end
+
+    test "streams the file with an attachment Content-Disposition header when both exist",
+         %{conn: conn} do
+      tmp_path = "/tmp/cake-book-#{System.unique_integer([:positive])}.pdf"
+      contents = "%PDF-1.7 fake test content"
+      File.write!(tmp_path, contents)
+
+      _book = parsed_book_fixture(%{source_file_path: tmp_path})
+
+      conn = get(conn, ~p"/books/download/#{tmp_path}")
+
+      assert conn.status == 200
+      assert response(conn, 200) == contents
+
+      assert {"content-disposition", disposition} =
+               Enum.find(conn.resp_headers, fn {k, _} -> k == "content-disposition" end)
+
+      assert disposition =~ ~s(filename="#{Path.basename(tmp_path)}")
+    after
+      tmp_files = Path.wildcard("/tmp/cake-book-*.pdf")
+      Enum.each(tmp_files, &File.rm/1)
+    end
+  end
+end

--- a/test/cake_web/live/chat_live_test.exs
+++ b/test/cake_web/live/chat_live_test.exs
@@ -1,0 +1,42 @@
+defmodule CakeWeb.ChatLiveTest do
+  @moduledoc """
+  Mount + render characterization tests for `CakeWeb.ChatLive`.
+
+  Submit / response-flow / citation-display tests require an end-to-end
+  mock of `Cake.Conversation` plus its `Cake.Search` and `Cake.Generation`
+  collaborators. Those are deferred from this PR — see #112's description.
+  """
+
+  use CakeWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "GET /chat" do
+    test "mounts and renders the chat surface", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/chat")
+
+      assert html =~ "Cake Chat"
+      assert html =~ "Ask a question..."
+      assert html =~ "Send"
+    end
+
+    test "starts with no messages and the loading indicator hidden", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/chat")
+
+      refute html =~ "Thinking..."
+      refute html =~ "msg-0"
+    end
+
+    test "ignores blank submissions without crashing the LiveView", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/chat")
+
+      result =
+        lv
+        |> form("form", %{"question" => "   "})
+        |> render_submit()
+
+      refute result =~ "Thinking..."
+      assert render(lv) =~ "Cake Chat"
+    end
+  end
+end

--- a/test/cake_web/live/search_live_test.exs
+++ b/test/cake_web/live/search_live_test.exs
@@ -1,0 +1,42 @@
+defmodule CakeWeb.SearchLiveTest do
+  @moduledoc """
+  Mount + render characterization tests for `CakeWeb.SearchLive`.
+
+  Search-flow tests require a mock of `Cake.Embeddings.embed/3` and
+  `Cake.Search.OpenSearch.search_chunks_with_context/5`. Those are
+  deferred from this PR — see #112's description.
+  """
+
+  use CakeWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "GET /search" do
+    test "mounts and renders the search form", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/search")
+
+      assert html =~ "Cake Search"
+      assert html =~ "Search books..."
+      assert html =~ "Search"
+    end
+
+    test "starts with no results, no loading indicator, and no error", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/search")
+
+      refute html =~ "Searching..."
+      refute html =~ "relevant sections found"
+    end
+
+    test "ignores blank queries without crashing the LiveView", %{conn: conn} do
+      {:ok, lv, _} = live(conn, ~p"/search")
+
+      result =
+        lv
+        |> form("form", %{"query" => "   "})
+        |> render_submit()
+
+      refute result =~ "Searching..."
+      assert render(lv) =~ "Cake Search"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Five new test files covering the **tractable subset** of #112's coverage gaps. The Books-pipeline-internals and ChatLive/SearchLive interaction flows are explicitly deferred — see "Out of scope" below for why.

### In this PR

- **`test/cake/books/page_content_test.exs`** + **`skipped_page_test.exs`** — smoke tests for the two NIF-decoded plain structs (raise from 0% to 100%).
- **`test/cake_web/controllers/books_controller_test.exs`** — covers all three branches of `download/2`: missing `ParsedBook` row → 404; row-without-on-disk-file → 404; success path with a real temp file + `Content-Disposition` attachment-header assertion.
- **`test/cake_web/live/chat_live_test.exs`** — mount + render of the chat surface; assertion that the LiveView starts with no messages and no loading indicator; blank-submission is a no-op.
- **`test/cake_web/live/search_live_test.exs`** — mount + render of the search form; clean initial state; blank-query no-op.

### Out of scope (deferred follow-ups)

The following items from #112 require infrastructure that doesn't exist in the tree yet. Rather than introduce that infrastructure as part of this PR, I'm flagging them for the user to slice into smaller follow-ups:

- **`Cake.Books.Pipeline` / `Cake.Books.Pdf.Pipeline` / `Cake.Books.PdfExtraction`** — needs a fixture PDF and a Rustler NIF mocking strategy. The current Books pipeline calls real `parsebooks.so`; characterizing it without that NIF requires either a behaviour seam (akin to `Cake.Embeddings.Behaviour` for OpenAI) or a small fixture PDF small enough to commit.
- **`Cake.Documents.Hexdocs.Pipeline` / `Cake.Documents.Hexdocs.Downloads`** — needs a fixture hexdocs tarball and HTTP mocking for the downloader. `Downloads` is a pure HTTP-bound module; tagging it `:integration` (per #109) is probably the right move.
- **`Cake.Documents.Hexdocs.Hexdoc` (8% → ?)** — likely characterizable in isolation against fixture HTML; deferred only because it pairs naturally with the Hexdocs pipeline work above.
- **ChatLive submit→response flow + citation rendering** — requires Mox stubs for `Cake.Conversation`'s `Cake.Search` / `Cake.Generation` / `Cake.Embeddings` collaborators all wired through the LiveView's spawned `Cake.Conversation` GenServer. Tractable, but a meaningful infra investment.
- **SearchLive search flow** — same shape: requires `Cake.Embeddings.embed/3` mocking (which is deferred under #110's audit findings) and `Cake.Search.OpenSearch` stubbing.
- **`Cake.Pipelines.Context`** — already raised from 0% by #107 via `pipelines_test.exs`; not duplicated here.

If the team wants the deferred items in scope before #105 closes, we should split #112 into two follow-up issues: one for "Books/Hexdocs ingest characterization with NIF/HTTP mocks" and one for "LiveView interaction flows with Conversation Mox stubs."

## Test plan

- [x] `mix test test/cake/books test/cake_web/controllers/books_controller_test.exs test/cake_web/live/chat_live_test.exs test/cake_web/live/search_live_test.exs` — 13 tests, 0 failures
- [x] Full suite: `mix test` — 7 properties, 399 tests, 0 failures (was 386 on master)
- [x] `mix compile --warnings-as-errors --force` — clean
- [x] `mix credo --strict` on the five new files — clean

Closes #112 **partially**. Suggest leaving #112 open after merge with a comment listing the deferred items, or splitting into follow-up issues.

Merge order: 6 of 7 in #105. Land after #114 and before #109.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SLF4u1pajnTMmAT7JYHUW)_