### PR TITLE
Configure CI gates, :integration tagging, and run mix format over the tree

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   quality-fast:
-    name: Compile + Credo
+    name: Compile + Credo + Format
     runs-on: ubuntu-latest
 
     steps:
@@ -61,6 +61,9 @@ jobs:
 
       - name: Credo (strict)
         run: mix credo --strict
+
+      - name: Format check
+        run: mix format --check-formatted
 
   test:
     name: Tests
@@ -121,8 +124,71 @@ jobs:
       - name: Compile
         run: mix compile --warnings-as-errors
 
-      - name: Run tests
-        run: mix test
+      - name: Run tests (excluding integration)
+        run: mix test --exclude integration
+
+  integration:
+    name: Integration Tests (merge gate)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cake_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Set up Rust (for Rustler NIFs)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Mix deps + build
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Cache Cargo registry + NIF target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/*/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('native/**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Run integration tests
+        run: mix test --only integration
 
   dialyzer:
     name: Dialyzer

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   quality-fast:
-    name: Compile + Credo + Format
+    name: Compile + Credo
     runs-on: ubuntu-latest
 
     steps:

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,7 @@ config :cake, Cake.Documents.Cluster,
 # For production it's recommended to configure a different adapter
 # at the `config/runtime.exs`.
 config :cake, Cake.Mailer, adapter: Swoosh.Adapters.Local
- 
+
 # config/config.exs
 config :cake, Oban,
   engine: Oban.Engines.Basic,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -41,8 +41,7 @@ if config_env() == :prod do
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     socket_options: maybe_ipv6
 
-  
-# The secret key base is used to sign/encrypt cookies and other secrets.
+  # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want
   # to check this value into version control, so we use an environment

--- a/lib/cake/accounts/user_notifier.ex
+++ b/lib/cake/accounts/user_notifier.ex
@@ -20,7 +20,8 @@ defmodule Cake.Accounts.UserNotifier do
   @doc """
   Deliver instructions to confirm account.
   """
-  @spec deliver_confirmation_instructions(%Cake.Accounts.User{}, String.t()) :: {:ok, Swoosh.Email.t()}
+  @spec deliver_confirmation_instructions(%Cake.Accounts.User{}, String.t()) ::
+          {:ok, Swoosh.Email.t()}
   def deliver_confirmation_instructions(user, url) do
     deliver(user.email, "Confirmation instructions", """
 
@@ -41,7 +42,8 @@ defmodule Cake.Accounts.UserNotifier do
   @doc """
   Deliver instructions to reset a user password.
   """
-  @spec deliver_reset_password_instructions(%Cake.Accounts.User{}, String.t()) :: {:ok, Swoosh.Email.t()}
+  @spec deliver_reset_password_instructions(%Cake.Accounts.User{}, String.t()) ::
+          {:ok, Swoosh.Email.t()}
   def deliver_reset_password_instructions(user, url) do
     deliver(user.email, "Reset password instructions", """
 
@@ -62,7 +64,8 @@ defmodule Cake.Accounts.UserNotifier do
   @doc """
   Deliver instructions to update a user email.
   """
-  @spec deliver_update_email_instructions(%Cake.Accounts.User{}, String.t()) :: {:ok, Swoosh.Email.t()}
+  @spec deliver_update_email_instructions(%Cake.Accounts.User{}, String.t()) ::
+          {:ok, Swoosh.Email.t()}
   def deliver_update_email_instructions(user, url) do
     deliver(user.email, "Update email instructions", """
 

--- a/lib/cake/generation/open_ai.ex
+++ b/lib/cake/generation/open_ai.ex
@@ -207,8 +207,6 @@ defmodule Cake.Generation.OpenAI do
   defp log_result({:error, reason}, model, started_at) do
     elapsed = System.monotonic_time(:millisecond) - started_at
 
-    Logger.warning(
-      "#{__MODULE__} model=#{model} elapsed_ms=#{elapsed} error=#{inspect(reason)}"
-    )
+    Logger.warning("#{__MODULE__} model=#{model} elapsed_ms=#{elapsed} error=#{inspect(reason)}")
   end
 end

--- a/lib/cake/jobs/document_ingestion_job.ex
+++ b/lib/cake/jobs/document_ingestion_job.ex
@@ -153,7 +153,12 @@ defmodule Cake.Jobs.DocumentIngestionJob do
   """
   @spec enqueue_for_version(atom(), atom(), {integer(), integer(), integer()}, String.t()) ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
-  def enqueue_for_version(source_pipeline, embedding_service, {major, minor, patch}, embedding_model)
+  def enqueue_for_version(
+        source_pipeline,
+        embedding_service,
+        {major, minor, patch},
+        embedding_model
+      )
       when is_atom(source_pipeline) and is_atom(embedding_service) and
              is_integer(major) and is_integer(minor) and is_integer(patch) and
              is_binary(embedding_model) do
@@ -187,7 +192,8 @@ defmodule Cake.Jobs.DocumentIngestionJob do
     Enum.map(list, &stringify_keys/1)
   end
 
-  defp stringify_keys(value) when is_atom(value) and not is_nil(value) and not is_boolean(value) do
+  defp stringify_keys(value)
+       when is_atom(value) and not is_nil(value) and not is_boolean(value) do
     Atom.to_string(value)
   end
 

--- a/lib/cake_web/live/chat_live.ex
+++ b/lib/cake_web/live/chat_live.ex
@@ -51,7 +51,9 @@ defmodule CakeWeb.ChatLive do
   def handle_info({:convo_response, response, citations}, socket) do
     {:noreply,
      assign(socket,
-       messages: [%{role: :assistant, text: response, citations: citations} | socket.assigns.messages],
+       messages: [
+         %{role: :assistant, text: response, citations: citations} | socket.assigns.messages
+       ],
        loading: false,
        citations: citations
      )}
@@ -98,19 +100,19 @@ defmodule CakeWeb.ChatLive do
           <span class="text-sm whitespace-pre-wrap">{msg.text}</span>
 
           <%!-- Citations (assistant messages only) --%>
-          <div :if={msg[:citations] != nil and msg[:citations] != []} class="mt-2 text-sm text-gray-600 border-t pt-2">
+          <div
+            :if={msg[:citations] != nil and msg[:citations] != []}
+            class="mt-2 text-sm text-gray-600 border-t pt-2"
+          >
             <div class="font-semibold mb-1">Sources:</div>
             <div class="space-y-1">
               <div :for={cite <- msg.citations} class="relative group inline-block">
-                <a
-                  href={"/books/download/#{cite.source_ref}"}
-                  class="text-blue-600 hover:underline"
-                >
-                  [<%= cite.new_index %>] <%= cite.label %>
+                <a href={"/books/download/#{cite.source_ref}"} class="text-blue-600 hover:underline">
+                  [{cite.new_index}] {cite.label}
                 </a>
                 <%!-- Hover tooltip --%>
                 <div class="hidden group-hover:block absolute z-10 bottom-full left-0 mb-1 w-80 p-3 bg-gray-800 text-white text-xs rounded shadow-lg">
-                  <%= cite.preview %>
+                  {cite.preview}
                 </div>
               </div>
             </div>

--- a/lib/cake_web/live/search_live.ex
+++ b/lib/cake_web/live/search_live.ex
@@ -23,7 +23,8 @@ defmodule CakeWeb.SearchLive do
 
       case run_search(query) do
         {:ok, results} ->
-          {:noreply, assign(socket, results: results, loading: false, form: to_form(%{"query" => ""}))}
+          {:noreply,
+           assign(socket, results: results, loading: false, form: to_form(%{"query" => ""}))}
 
         {:error, error} ->
           {:noreply, assign(socket, loading: false, error: inspect(error))}

--- a/priv/repo/migrations/20251217152311_create_parsed_books.exs
+++ b/priv/repo/migrations/20251217152311_create_parsed_books.exs
@@ -26,7 +26,7 @@ defmodule Cake.Repo.Migrations.CreateParsedBooks do
 
       timestamps(type: :utc_datetime)
     end
+
     create unique_index(:parsed_books, [:file_hash])
   end
-
 end

--- a/priv/repo/migrations/20251217152316_create_chunks.exs
+++ b/priv/repo/migrations/20251217152316_create_chunks.exs
@@ -11,7 +11,9 @@ defmodule Cake.Repo.Migrations.CreateChunks do
       add :word_count, :integer
       add :char_count, :integer
       add :embedding, {:array, :float}
-      add :parsed_book_id, references(:parsed_books, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :parsed_book_id, references(:parsed_books, type: :binary_id, on_delete: :delete_all),
+        null: false
 
       timestamps(type: :utc_datetime)
     end

--- a/test/cake/citations_test.exs
+++ b/test/cake/citations_test.exs
@@ -34,7 +34,8 @@ defmodule Cake.CitationsTest do
   @meta_3 %{
     id: {"elixir_in_action.pdf", 40},
     label: "Elixir in Action, p. 101 — Tasks",
-    preview: "Tasks are processes meant to execute one particular action throughout their lifetime.",
+    preview:
+      "Tasks are processes meant to execute one particular action throughout their lifetime.",
     source_ref: "assets/static/elixir_in_action.pdf",
     extras: %{
       book_title: "Elixir in Action",

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -128,10 +128,10 @@ defmodule Cake.ConversationTest do
       end)
 
       expect(Cake.Search.Mock, :search_chunks_with_context, fn :hybrid,
-                                                                _q,
-                                                                _emb,
-                                                                _expand,
-                                                                _opts ->
+                                                               _q,
+                                                               _emb,
+                                                               _expand,
+                                                               _opts ->
         {:ok, [{chunk, %{os_score: 1.0}}]}
       end)
 
@@ -698,7 +698,8 @@ defmodule Cake.ConversationTest do
       {:ok, reply_to: reply_to}
     end
 
-    test "successful turn pushes {:convo_response, _, _} to the configured reply_to, not the caller", %{reply_to: reply_to} do
+    test "successful turn pushes {:convo_response, _, _} to the configured reply_to, not the caller",
+         %{reply_to: reply_to} do
       chunk = %ConvoChunk{
         embedding: [0.1, 0.2, 0.3],
         prompt_text: "x",
@@ -731,7 +732,8 @@ defmodule Cake.ConversationTest do
       refute_received {:convo_response, _, _}
     end
 
-    test "failed turn pushes {:convo_error, reason} to the configured reply_to, not the caller", %{reply_to: reply_to} do
+    test "failed turn pushes {:convo_error, reason} to the configured reply_to, not the caller",
+         %{reply_to: reply_to} do
       expect(Cake.Embeddings.Mock, :embed, fn _, _, _ ->
         {:ok, %{attrs: %{embedding: [0.1, 0.2, 0.3]}}}
       end)
@@ -856,10 +858,14 @@ defmodule Cake.ConversationTest do
 
   describe "pipeline stages" do
     test "resolve_search_results/2 returns cached results when search_results is non-empty" do
-      cached = [{%ConvoChunk{prompt_text: "cached"}, %{os_score: 1.0, cosine_score: 0.9, relevance_score: 0.95}}]
+      cached = [
+        {%ConvoChunk{prompt_text: "cached"},
+         %{os_score: 1.0, cosine_score: 0.9, relevance_score: 0.95}}
+      ]
 
       state =
-        struct!(Cake.Conversation.State,
+        struct!(
+          Cake.Conversation.State,
           Map.merge(mocked_opts(), %{search_results: cached})
         )
 
@@ -998,11 +1004,17 @@ defmodule Cake.ConversationTest do
 
     test "process_response/3 wraps Responses.process result in :ok tuple" do
       expect(Cake.Responses.Mock, :process, fn "raw text", [], [] ->
-        %Cake.Responses.Result{raw_text: "raw text", final_text: "processed", citations: [], warnings: []}
+        %Cake.Responses.Result{
+          raw_text: "raw text",
+          final_text: "processed",
+          citations: [],
+          warnings: []
+        }
       end)
 
       state =
-        struct!(Cake.Conversation.State,
+        struct!(
+          Cake.Conversation.State,
           Map.put(mocked_opts(), :responses, Cake.Responses.Mock)
         )
 
@@ -1082,9 +1094,20 @@ defmodule Cake.ConversationTest do
 
   describe "apply_selection/2" do
     test "filters candidates to selected IDs and assigns 1-based indices" do
-      c1 = %ConvoChunk{prompt_text: "a", metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}}
-      c2 = %ConvoChunk{prompt_text: "b", metadata: %{id: "id-2", label: "L", preview: "p", source_ref: nil, extras: %{}}}
-      c3 = %ConvoChunk{prompt_text: "c", metadata: %{id: "id-3", label: "L", preview: "p", source_ref: nil, extras: %{}}}
+      c1 = %ConvoChunk{
+        prompt_text: "a",
+        metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
+
+      c2 = %ConvoChunk{
+        prompt_text: "b",
+        metadata: %{id: "id-2", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
+
+      c3 = %ConvoChunk{
+        prompt_text: "c",
+        metadata: %{id: "id-3", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
 
       candidates = [
         {c1, %{os_score: 1.0}},
@@ -1099,25 +1122,40 @@ defmodule Cake.ConversationTest do
     end
 
     test "selecting all candidates returns all with indices" do
-      c1 = %ConvoChunk{prompt_text: "a", metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}}
+      c1 = %ConvoChunk{
+        prompt_text: "a",
+        metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
+
       candidates = [{c1, %{os_score: 1.0}}]
 
       assert {:ok, [{1, {^c1, _}}]} = Conversation.apply_selection(candidates, ["id-1"])
     end
 
     test "errors on unknown doc IDs" do
-      c1 = %ConvoChunk{prompt_text: "a", metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}}
+      c1 = %ConvoChunk{
+        prompt_text: "a",
+        metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
+
       candidates = [{c1, %{os_score: 1.0}}]
 
-      assert {:error, {:unknown_doc_ids, unknown}} = Conversation.apply_selection(candidates, ["id-1", "id-999"])
+      assert {:error, {:unknown_doc_ids, unknown}} =
+               Conversation.apply_selection(candidates, ["id-1", "id-999"])
+
       assert "id-999" in unknown
     end
 
     test "empty doc_ids returns empty indexed list" do
-      c1 = %ConvoChunk{prompt_text: "a", metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}}
+      c1 = %ConvoChunk{
+        prompt_text: "a",
+        metadata: %{id: "id-1", label: "L", preview: "p", source_ref: nil, extras: %{}}
+      }
+
       candidates = [{c1, %{os_score: 1.0}}]
 
-      assert {:error, {:unknown_doc_ids, _}} = Conversation.apply_selection(candidates, ["nonexistent"])
+      assert {:error, {:unknown_doc_ids, _}} =
+               Conversation.apply_selection(candidates, ["nonexistent"])
     end
   end
 
@@ -1138,7 +1176,12 @@ defmodule Cake.ConversationTest do
       end)
 
       expect(Cake.Responses.Mock, :process, fn _raw, _indexed, _opts ->
-        %Cake.Responses.Result{raw_text: "answer", final_text: "answer", citations: [], warnings: []}
+        %Cake.Responses.Result{
+          raw_text: "answer",
+          final_text: "answer",
+          citations: [],
+          warnings: []
+        }
       end)
 
       {:ok, pid} = start_supervised({Conversation, mocked_opts()})

--- a/test/cake/documents/parsed_document_property_test.exs
+++ b/test/cake/documents/parsed_document_property_test.exs
@@ -19,7 +19,9 @@ defmodule Cake.Documents.ParsedDocumentPropertyTest do
   # Strings that may contain interleaved NUL bytes — exactly the input that
   # exercises the sanitizer's filtering branch.
   defp string_with_nuls do
-    gen all(parts <- list_of(one_of([string(:utf8, max_length: 8), constant("\0")]), max_length: 16)) do
+    gen all(
+          parts <- list_of(one_of([string(:utf8, max_length: 8), constant("\0")]), max_length: 16)
+        ) do
       Enum.join(parts)
     end
   end

--- a/test/cake/failed_ingests_test.exs
+++ b/test/cake/failed_ingests_test.exs
@@ -39,7 +39,9 @@ defmodule Cake.FailedIngestsTest do
         last_retried_at: ~U[2026-04-10 01:14:00Z]
       }
 
-      assert {:ok, %FailedIngest{} = failed_ingest} = FailedIngests.create_failed_ingest(valid_attrs)
+      assert {:ok, %FailedIngest{} = failed_ingest} =
+               FailedIngests.create_failed_ingest(valid_attrs)
+
       assert failed_ingest.pipeline_behaviour == "some pipeline_behaviour"
       assert failed_ingest.pipeline_implementation == "some pipeline_implementation"
       assert failed_ingest.step == "some step"
@@ -86,14 +88,20 @@ defmodule Cake.FailedIngestsTest do
 
     test "update_failed_ingest/2 with invalid data returns error changeset" do
       failed_ingest = failed_ingest_fixture()
-      assert {:error, %Ecto.Changeset{}} = FailedIngests.update_failed_ingest(failed_ingest, @invalid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               FailedIngests.update_failed_ingest(failed_ingest, @invalid_attrs)
+
       assert failed_ingest == FailedIngests.get_failed_ingest!(failed_ingest.id)
     end
 
     test "delete_failed_ingest/1 deletes the failed_ingest" do
       failed_ingest = failed_ingest_fixture()
       assert {:ok, %FailedIngest{}} = FailedIngests.delete_failed_ingest(failed_ingest)
-      assert_raise Ecto.NoResultsError, fn -> FailedIngests.get_failed_ingest!(failed_ingest.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        FailedIngests.get_failed_ingest!(failed_ingest.id)
+      end
     end
 
     test "change_failed_ingest/1 returns a failed_ingest changeset" do

--- a/test/cake/prompt_test.exs
+++ b/test/cake/prompt_test.exs
@@ -35,7 +35,10 @@ defmodule Cake.PromptTest do
     test "relevance floor applies before chunk ceiling" do
       above = Enum.map(1..7, fn _ -> scored_chunk(0.8) end)
       below = Enum.map(1..8, fn _ -> scored_chunk(0.1) end)
-      {indexed, _quality} = Cake.Prompt.prepare_context(above ++ below, max_chunks: 10, min_relevance: 0.3)
+
+      {indexed, _quality} =
+        Cake.Prompt.prepare_context(above ++ below, max_chunks: 10, min_relevance: 0.3)
+
       assert length(indexed) == 7
     end
 
@@ -49,7 +52,14 @@ defmodule Cake.PromptTest do
     end
 
     test "indices are dense after filtering" do
-      chunks = [scored_chunk(0.9), scored_chunk(0.1), scored_chunk(0.7), scored_chunk(0.05), scored_chunk(0.5)]
+      chunks = [
+        scored_chunk(0.9),
+        scored_chunk(0.1),
+        scored_chunk(0.7),
+        scored_chunk(0.05),
+        scored_chunk(0.5)
+      ]
+
       {indexed, _quality} = Cake.Prompt.prepare_context(chunks, min_relevance: 0.3)
       indices = Enum.map(indexed, fn {idx, _} -> idx end)
       assert indices == [1, 2, 3]
@@ -114,7 +124,8 @@ defmodule Cake.PromptTest do
       history = ["first_q", "first_a", "second_q", "second_a"]
       messages = Cake.Prompt.build(indexed, question, history)
 
-      user_messages = Enum.filter(messages, fn msg -> msg.role == "user" and msg.content != question end)
+      user_messages =
+        Enum.filter(messages, fn msg -> msg.role == "user" and msg.content != question end)
 
       [first_user | rest] = user_messages
       assert first_user.content == "first_q"
@@ -193,7 +204,9 @@ defmodule Cake.PromptTest do
       assert String.contains?(message, "[1]")
       assert String.contains?(message, "cite")
       assert String.contains?(message, "fabricate")
-      assert String.contains?(message, "cannot be found") or String.contains?(message, "not in the context")
+
+      assert String.contains?(message, "cannot be found") or
+               String.contains?(message, "not in the context")
     end
 
     test "contains the context block" do

--- a/test/cake/search/open_search_test.exs
+++ b/test/cake/search/open_search_test.exs
@@ -44,9 +44,7 @@ defmodule Cake.Search.OpenSearchTest do
     test "routes index_name/0 through the :gds module" do
       _ =
         try do
-          OpenSearch.search_chunks_with_context(:keyword, "anything", nil, 0,
-            gds: FixtureGDS
-          )
+          OpenSearch.search_chunks_with_context(:keyword, "anything", nil, 0, gds: FixtureGDS)
         rescue
           _ -> :rescued
         catch
@@ -61,9 +59,7 @@ defmodule Cake.Search.OpenSearchTest do
     test "routes search_fields/0 through the :gds module" do
       _ =
         try do
-          OpenSearch.search_chunks_with_context(:keyword, "anything", nil, 0,
-            gds: FixtureGDS
-          )
+          OpenSearch.search_chunks_with_context(:keyword, "anything", nil, 0, gds: FixtureGDS)
         rescue
           _ -> :rescued
         catch

--- a/test/cake/search/query_property_test.exs
+++ b/test/cake/search/query_property_test.exs
@@ -37,7 +37,9 @@ defmodule Cake.Search.QueryPropertyTest do
       last_min_score_step = steps |> Enum.filter(&match?({:min_score, _}, &1)) |> List.last()
 
       expected_size = if last_size_step, do: elem(last_size_step, 1), else: query.size
-      expected_min_score = if last_min_score_step, do: elem(last_min_score_step, 1), else: query.min_score
+
+      expected_min_score =
+        if last_min_score_step, do: elem(last_min_score_step, 1), else: query.min_score
 
       assert result.size == expected_size
       assert result.min_score == expected_min_score
@@ -45,7 +47,7 @@ defmodule Cake.Search.QueryPropertyTest do
   end
 
   property "permutations of builder steps produce the same clause sets" do
-    check all steps <- QueryGenerators.builder_sequence() do
+    check all(steps <- QueryGenerators.builder_sequence()) do
       base = Query.new("test")
       result1 = QueryGenerators.apply_sequence(base, steps)
       result2 = QueryGenerators.apply_sequence(base, Enum.shuffle(steps))
@@ -61,7 +63,7 @@ defmodule Cake.Search.QueryPropertyTest do
   # ---------------------------------------------------------------------------
 
   property "to_query_map/1 always produces a map with the correct shape" do
-    check all query <- QueryGenerators.query() do
+    check all(query <- QueryGenerators.query()) do
       map = Query.to_query_map(query)
 
       assert is_integer(map.size)
@@ -72,7 +74,7 @@ defmodule Cake.Search.QueryPropertyTest do
   end
 
   property "to_query_map/1 preserves clause counts" do
-    check all query <- QueryGenerators.query() do
+    check all(query <- QueryGenerators.query()) do
       map = Query.to_query_map(query)
 
       assert length(get_in(map, [:query, :bool, :must])) == length(query.must)
@@ -82,7 +84,7 @@ defmodule Cake.Search.QueryPropertyTest do
   end
 
   property "to_query_map/1 preserves clause content" do
-    check all query <- QueryGenerators.query() do
+    check all(query <- QueryGenerators.query()) do
       map = Query.to_query_map(query)
 
       assert MapSet.new(get_in(map, [:query, :bool, :must])) == MapSet.new(query.must)
@@ -92,7 +94,7 @@ defmodule Cake.Search.QueryPropertyTest do
   end
 
   property "to_query_map/1 includes min_score iff it is non-nil" do
-    check all query <- QueryGenerators.query() do
+    check all(query <- QueryGenerators.query()) do
       map = Query.to_query_map(query)
 
       if is_nil(query.min_score) do

--- a/test/support/fixtures/failed_ingests_fixtures.ex
+++ b/test/support/fixtures/failed_ingests_fixtures.ex
@@ -12,15 +12,15 @@ defmodule Cake.FailedIngestsFixtures do
     {:ok, failed_ingest} =
       attrs
       |> Enum.into(%{
-         error_text: "some  error_text",
-         input_identifier: "some  input_identifier",
-         last_retried_at: ~U[2026-04-10 01:14:00Z],
-         pipeline_behaviour: "some  pipeline_behaviour",
-         pipeline_fatal: true,
-         pipeline_implementation: "some  pipeline_implementation",
-         retry_count: 42,
-         step: "some  step",
-         version: "some  version"
+        error_text: "some  error_text",
+        input_identifier: "some  input_identifier",
+        last_retried_at: ~U[2026-04-10 01:14:00Z],
+        pipeline_behaviour: "some  pipeline_behaviour",
+        pipeline_fatal: true,
+        pipeline_implementation: "some  pipeline_implementation",
+        retry_count: 42,
+        step: "some  step",
+        version: "some  version"
       })
       |> Cake.FailedIngests.create_failed_ingest()
 

--- a/test/support/query_generators.ex
+++ b/test/support/query_generators.ex
@@ -75,7 +75,13 @@ defmodule Cake.QueryGenerators do
   @doc "Generates a tagged tuple representing a single builder call."
   @spec builder_step() :: StreamData.t(step())
   def builder_step do
-    StreamData.one_of([knn_step(), match_step(), filter_term_step(), min_score_step(), size_step()])
+    StreamData.one_of([
+      knn_step(),
+      match_step(),
+      filter_term_step(),
+      min_score_step(),
+      size_step()
+    ])
   end
 
   @doc "Generates a list of builder steps."

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(exclude: [:integration])
 Ecto.Adapters.SQL.Sandbox.mode(Cake.Repo, :manual)
 
 # Skip OpenSearch operations in tests to avoid connection errors


### PR DESCRIPTION
## Summary

- **`test/test_helper.exs`**: `ExUnit.start(exclude: [:integration])` so `mix test` skips `:integration`-tagged tests by default. Five existing tags in `test/cake/jobs/document_ingestion_job_test.exs` are now properly excluded from the on-push gate.
- **`.github/workflows/quality.yml`**:
  - Add `mix format --check-formatted` to the quality-fast job so format drift fails the gate.
  - Update the test job to `mix test --exclude integration`.
  - Add a separate `integration` job that runs `mix test --only integration` on `pull_request` as a merge gate, with the same Postgres service container.
- **`mix format`** over the tree to clean pre-existing drift in 18 source files (formatter-only changes — no logic edits) so the new `--check-formatted` gate passes from day one.

## No new `:integration` tags needed yet

The current tree's test infrastructure already insulates unit tests:
- `Application.put_env(:cake, :skip_opensearch, true)` in `test_helper.exs` short-circuits `Cake.Pipelines.add_to_opensearch/4`.
- Mox-based stubs cover `Cake.Embeddings.Behaviour`, `Cake.Responses.Behaviour`, and `Cake.Search.Behaviour`.
- `Cake.Test.GenerationStub` covers LLM generation.
- No existing test invokes the Rustler NIF directly.

Future PRs that introduce NIF-bound or live-HTTP tests (e.g., the deferred Books-pipeline and Hexdocs-pipeline characterization from #112) should tag those tests `:integration` themselves.

## Test plan

- [x] `mix test` — 7 properties, 386 tests, 0 failures, **5 excluded** (the existing `document_ingestion_job_test.exs` tags)
- [x] `mix compile --warnings-as-errors --force` — clean
- [x] `mix credo --strict` — exit 0 (12 pre-existing TODO design-level suggestions; same as master)
- [x] `mix format --check-formatted` — clean
- [x] YAML syntax of the updated workflow validated locally

Closes #109.

Merge order: 7 of 7 in #105. Land **last** so the per-file format pass and `:integration` tagging sweep all the new test files contributed by #107, #108, #110, #112, and #114 in a single commit (this PR rebases against the others rather than vice versa).

---
_Generated by [Claude Code](https://claude.ai/code/session_014SLF4u1pajnTMmAT7JYHUW)_