### PR TITLE
Fix 3: route index names through GDS callbacks (#155)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -45,8 +45,23 @@ fi
 ###############################################################################
 OTP_VERSION="${OTP_VERSION:-27.3.4.11}"
 ELIXIR_VERSION="${ELIXIR_VERSION:-1.17.3}"
+MIN_OTP_MAJOR="${MIN_OTP_MAJOR:-26}"
 
-if ! command -v erl >/dev/null 2>&1; then
+# Ubuntu Noble's apt `erlang` package installs OTP 25 to /usr/bin/erl, so a
+# bare `command -v erl` check would short-circuit and skip the OTP 27 install
+# — leaving the broken `:httpc` empty-`te:`-header behavior in place. Force
+# install whenever the visible OTP is older than MIN_OTP_MAJOR (or unreadable).
+need_otp_install=true
+if command -v erl >/dev/null 2>&1; then
+  current_otp=$(erl -noshell -eval 'io:format("~s", [erlang:system_info(otp_release)]), halt().' 2>/dev/null || echo "0")
+  if [ "${current_otp}" -ge "${MIN_OTP_MAJOR}" ] 2>/dev/null; then
+    need_otp_install=false
+  else
+    echo "==> Detected OTP ${current_otp} (< ${MIN_OTP_MAJOR}); installing OTP ${OTP_VERSION} to override."
+  fi
+fi
+
+if [ "$need_otp_install" = "true" ]; then
   echo "==> Installing build deps..."
   # Tolerate failing third-party PPAs; we only need the main Ubuntu archive.
   $SUDO apt-get update -y || true
@@ -73,8 +88,22 @@ if ! command -v erl >/dev/null 2>&1; then
   done
 fi
 
-if ! command -v elixir >/dev/null 2>&1 || ! command -v mix >/dev/null 2>&1; then
-  OTP_MAJOR=$(erl -noshell -eval 'io:format("~s", [erlang:system_info(otp_release)]), halt().')
+OTP_MAJOR=$(erl -noshell -eval 'io:format("~s", [erlang:system_info(otp_release)]), halt().')
+
+# If Elixir is on PATH but compiled against a different OTP than the one we
+# just selected (e.g. a stale /opt/elixir from a prior OTP 25 run), it must be
+# reinstalled — running it would crash on BEAM/abi mismatch.
+need_elixir_install=true
+if command -v elixir >/dev/null 2>&1 && command -v mix >/dev/null 2>&1; then
+  elixir_otp=$(elixir --version 2>/dev/null | sed -n 's/.*compiled with Erlang\/OTP \([0-9]*\).*/\1/p')
+  if [ -n "${elixir_otp}" ] && [ "${elixir_otp}" = "${OTP_MAJOR}" ]; then
+    need_elixir_install=false
+  else
+    echo "==> Elixir compiled with OTP ${elixir_otp:-unknown}, need OTP ${OTP_MAJOR}; reinstalling."
+  fi
+fi
+
+if [ "$need_elixir_install" = "true" ]; then
   echo "==> Detected OTP ${OTP_MAJOR}; installing Elixir ${ELIXIR_VERSION}..."
   $SUDO mkdir -p /opt/elixir
   curl -fsSL \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,23 @@ The dev environment runs three containers via `docker-compose.yml`: `cake_app`, 
 
 ---
 
+## Claude Code on the Web — Environment Gotchas
+
+**OTP 25 `:httpc` empty `te:` header → proxy 503s on `mix deps.get`.** Ubuntu Noble's apt `erlang` package is OTP 25, which has a `:httpc` bug that emits an empty `te:` header. The egress proxy in front of Fastly rejects every such request with 503, so `mix deps.get` fails even when `repo.hex.pm` is allowlisted. Fixed in OTP 26.2.5 / 27.0+; the SessionStart hook (`.claude/hooks/session-start.sh`) installs OTP 27 from `builds.hex.pm` to override.
+
+The hook's gate for OTP install was originally a bare `command -v erl` check, which short-circuited and skipped the OTP 27 install when apt had already put OTP 25 at `/usr/bin/erl`. The current hook checks the OTP *major version* (`MIN_OTP_MAJOR=26`) and force-installs `OTP_VERSION=27.3.4.11` when the visible OTP is older. It also reinstalls Elixir whenever its compile-time OTP doesn't match the active OTP, so a leftover `/opt/elixir` from a prior OTP 25 run gets refreshed instead of crashing on BEAM/abi mismatch.
+
+**Diagnostic if you see this regress:**
+- `SessionStart` message banner shows `OTP 25` (or `compiled with Erlang/OTP 25`).
+- `mix deps.get` fails with repeated `upstream connect error or disconnect/reset before headers ... connection termination` lines.
+- `erl -noshell -eval 'io:format("~s", [erlang:system_info(otp_release)]), halt().'` returns `25`.
+
+**Manual recovery in a session where the hook didn't apply:** download `https://builds.hex.pm/builds/otp/ubuntu-24.04/OTP-27.3.4.11.tar.gz` to `/opt/otp`, run `cd /opt/otp && ./Install -minimal /opt/otp`, link the binaries into `/usr/local/bin`, then download `https://github.com/elixir-lang/elixir/releases/download/v1.17.3/elixir-otp-27.zip` to `/opt/elixir` and link `elixir`/`elixirc`/`iex`/`mix` into `/usr/local/bin`. Re-run `mix deps.get`.
+
+**Don't** "fix" this by adding hex.pm to a different allowlist or reaching for a non-`mix` package fetch — the underlying cause is the Erlang `:httpc` bug, and the fix is the OTP version.
+
+---
+
 ## Known Defects and Deferred Work
 
 If your task touches any of these, flag it to the user rather than silently resolving or ignoring it.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,64 @@ OpenSearch queries support three modes via `search_type`: `:keyword` (BM25 multi
 
 ---
 
+## What Cake Is Agnostic Of (And What It Isn't)
+
+Cake is intended to be substitutable at every layer where the substitution is meaningful and the substitute can satisfy a published contract. "Agnostic" here is concrete: it means there exists a behaviour, protocol, or config key that lets you swap one value for another without editing source under `lib/`. Where Cake is *not* agnostic, that fact is load-bearing — usually because the constraint is baked into infrastructure (supervision tree, OpenSearch index shape) or because the variability isn't useful enough to justify the abstraction cost.
+
+**Cake is agnostic of:**
+
+- **Which GDS is being processed.** The `Cake.GDS` behaviour is the central abstraction; any module implementing it (with `index_name/0`, `search_fields/0`, `load_from_hits/1`, `expand_with_neighbors/2`) can be threaded through the conversation, search, and pipeline layers. `Cake.Conversation` accepts `:gds` as a required opt and never refers to a specific GDS module.
+- **Which provider supplies embeddings.** `Cake.Embeddings.Behaviour` defines the contract; the provider is selected by the first argument to `embed/3` (e.g. `:openai`, future `:voyage`). `Cake.Embeddings` is the default implementation; tests stub `Cake.Embeddings.Mock`. The module to call is configurable per-call site via `:embeddings_module` in `:cake` application config.
+- **Which provider supplies generation.** `Cake.Generation` is a behaviour with `Cake.Generation.OpenAI` as the real implementation and `Cake.Generation.Anthropic` as a placeholder.
+- **Which search backend serves retrieval.** `Cake.Search` is a behaviour; `Cake.Search.OpenSearch` is the only current implementation. Swapping in a different backend means writing a new module that implements the behaviour.
+- **Which post-processor handles responses.** `Cake.Responses.Behaviour` defines the contract for parsing citation markers and assembling the structured response.
+- **Source format within a GDS.** `Cake.Books.Pipeline` admits any number of implementations (currently `Cake.Books.Pdf.Pipeline`; future `Epub`, `Word`, `Excel`, etc.). `Cake.Documents.Pipeline` admits any number of implementations (currently `Cake.Documents.Hexdocs.Pipeline`; future `Javadocs`, `Rustdocs`, etc.).
+- **OpenSearch index name.** Each GDS declares its index via `index_name/0`. Pipeline modules and `Cake.Documents.Cluster` read from the GDS callback; the literal string lives in exactly one place.
+- **Embedding model name, response model name, and default provider.** All three are `:cake` application config keys (see "Configuration" below). Switching from `text-embedding-ada-002` to a successor model is a config change, not a source edit.
+- **KNN search depth.** `ef_search` is overridable per call via the `:ef_search` opt to `search_chunks/4` (and friends), threaded through `Cake.Search.Query.knn/5`'s `method_parameters.ef_search`.
+- **HNSW index-build hyperparameters within tolerance.** `ef_construction` and `m` are currently constants in `Cake.Documents.Cluster.build_mapping/1`; tunable, but only by editing source. Listed in the issue tracker as a deferred config-extraction.
+
+**Cake is not agnostic of:**
+
+- **The Postgres + OpenSearch backbone.** Both are wired into the supervision tree (`Cake.Repo`, `Cake.Documents.Cluster`) and assumed by every pipeline. Replacing either is a structural change, not a config swap.
+- **The behaviour-driven design itself.** Modules that depend on external services accept collaborator modules as arguments — primarily for Mox testability, secondarily for runtime polymorphism. There is no escape hatch.
+- **The retrieve → prompt → generate → cite pipeline shape.** The `Conversation` orchestrator hardcodes this sequence. Reordering or skipping stages requires editing `Conversation`.
+- **The embedding dimension *within* an existing OpenSearch index.** `default_embedding_dimension` is a config key, but it's read at index-creation time only. Once an index exists, its `knn_vector` dimension is frozen — switching to a model with a different vector size requires a reindex, not just a config flip. This is an OpenSearch property, not a Cake decision.
+- **Phoenix LiveView for the UI.** `CakeWeb.ChatLive` and `CakeWeb.SearchLive` are built directly on LiveView. There is no UI-layer behaviour. A non-LiveView frontend would need to talk to `Cake.Conversation` directly via its public API.
+- **The 1:1 GDS-to-pipeline-behaviour cardinality.** Each GDS owns its own pipeline behaviour by design (see "Cardinality"). There is deliberately no master `Cake.Ingestion` behaviour unifying the two.
+
+**How config vars relate.** Agnosticism axes split into two kinds of pluggability:
+
+- **Module-level pluggability** uses behaviours: substitute one module that implements the contract for another (e.g. `Cake.Search` → `Cake.Search.OpenSearch` or a Mox stub). The selection of which module to use is itself sometimes config-driven (e.g. `:embeddings_module`), sometimes opt-driven (e.g. `Cake.Conversation`'s `:gds`, `:embeddings`, `:search`, `:generation`, `:responses`).
+- **Value-level pluggability** uses `:cake` application config keys: substitute one value (a string, integer, atom) for another without touching modules at all. Embedding model name, response model name, embedding dimension, default provider all live here.
+
+The two kinds compose: the `:default_provider` atom selects a clause inside the configured `:embeddings_module`. Both knobs are independently overridable, which is what the LiveView wiring relies on for testability.
+
+---
+
+## Configuration: `:cake` Application Config Keys
+
+These keys live under the `:cake` application and are defaulted in `config/config.exs`. Override them per-environment in `config/dev.exs`, `config/test.exs`, `config/runtime.exs`, or per-test via `Application.put_env(:cake, key, value)`.
+
+| Key | Type | Default | Purpose |
+|---|---|---|---|
+| `:default_embedding_model` | string | `"text-embedding-ada-002"` | Embedding model name passed to the provider's `embed/3`. Read by `CakeWeb.ChatLive` (when starting a `Conversation`) and `CakeWeb.SearchLive` (when issuing a one-shot search). |
+| `:default_embedding_dimension` | integer | `1536` | Vector dimension declared in the OpenSearch `knn_vector` mapping. Read by `Cake.Documents.Cluster.build_mapping/1` at index-creation time. **Only affects new indexes** — see the agnosticism note above. |
+| `:default_response_model` | string | `"gpt-4o-mini"` | LLM model name passed to `Cake.Generation.complete/3`. Read by `CakeWeb.ChatLive`. |
+| `:default_provider` | atom | `:openai` | Provider atom (the dispatch key) passed to embeddings/generation behaviours. Read by both LiveViews. |
+| `:embeddings_module` | module | `Cake.Embeddings` | Module that implements `Cake.Embeddings.Behaviour`. Tests override to `Cake.Embeddings.Mock`. Read by `CakeWeb.SearchLive`, `Cake.Books.Pipeline`, and `Cake.Documents.Pipeline`. |
+| `:skip_opensearch` | boolean | `false` (set to `true` in `test_helper.exs`) | Skip OpenSearch writes during ingestion. Test/dev flag. |
+
+The same `:cake` namespace also holds per-module config (under module-name keys, not bare atoms):
+
+- `config :cake, Cake.Embeddings, openai_key: ..., base_url: ...` — set in `config/dev.exs` and `config/runtime.exs`.
+- `config :cake, Cake.Generation.OpenAI, openai_key: ..., response_url: ...` — set in `config/dev.exs`, `config/test.exs`, and `config/runtime.exs`. The test config also sets `:plug` to a `Req.Test` stub.
+- `config :cake, Cake.Documents.Cluster, url: ..., username: ..., password: ...` — set in `config/config.exs` (with env-var fallback) and `config/dev.exs`.
+
+Adding a new value-level config key: default it in `config/config.exs`, override it where it differs per environment, and document it in the table above. Adding a new module-level config: pick a sensible per-environment placement (most belong in `runtime.exs` for prod and `dev.exs`/`test.exs` for non-prod).
+
+---
+
 ## Roadmap: Planned and Deferred
 
 **Post-demo planned:** conversation layer decomposition (extract `Prompt` and `Generation` fully; collapse `Responses` to post-processing only), PubSub migration, test coverage expansion, `Generation.Behaviour` extraction, generalize `Responses` beyond `Chunk`, `search_fields/0` behaviour extraction, `Conversation.start_link` struct migration, Word/Excel/CSV/JPG pipelines.

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,11 @@ import Config
 
 config :cake,
   ecto_repos: [Cake.Repo],
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime],
+  default_embedding_model: "text-embedding-ada-002",
+  default_embedding_dimension: 1536,
+  default_response_model: "gpt-4o-mini",
+  default_provider: :openai
 
 # Configures the endpoint
 config :cake, CakeWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,6 +35,13 @@ if config_env() == :prod do
     openai_key: System.get_env("OPENAI_KEY"),
     base_url: "https://api.openai.com/v1/embeddings"
 
+  # Config for LLM completion (Cake.Generation.OpenAI)
+  config :cake, Cake.Generation.OpenAI,
+    openai_key:
+      System.get_env("OPENAI_KEY") ||
+        raise("environment variable OPENAI_KEY is missing"),
+    response_url: "https://api.openai.com/v1/responses"
+
   config :cake, Cake.Repo,
     # ssl: true,
     url: database_url,

--- a/lib/cake/books/pipeline.ex
+++ b/lib/cake/books/pipeline.ex
@@ -24,7 +24,6 @@ defmodule Cake.Books.Pipeline do
   require Logger
 
   @cluster Cake.Documents.Cluster
-  @index "chunks_of_books"
 
   @callback load_binary(String.t()) :: {:ok, {String.t(), binary()}} | {:error, any()}
   @callback parse({String.t(), binary()}) :: {ParsedBook.t(), [Chunk.t()]}
@@ -49,7 +48,7 @@ defmodule Cake.Books.Pipeline do
          {:ok, embedded_chunks} <-
            embed_all_chunks(persisted_books_and_chunks, embedding_service, embedding_model, ctx),
          opensearch_chunks <-
-           Pipelines.add_to_opensearch(embedded_chunks, @index, @cluster, ctx),
+           Pipelines.add_to_opensearch(embedded_chunks, ParsedBook.index_name(), @cluster, ctx),
          :ok <- Stream.run(opensearch_chunks) do
       {:ok, format_pipeline.success_message()}
     else
@@ -314,7 +313,12 @@ defmodule Cake.Books.Pipeline do
     if Application.get_env(:cake, :skip_opensearch, false) do
       :ok
     else
-      case Snap.Document.update(@cluster, @index, %{doc: chunk, doc_as_upsert: true}, chunk.id) do
+      case Snap.Document.update(
+             @cluster,
+             ParsedBook.index_name(),
+             %{doc: chunk, doc_as_upsert: true},
+             chunk.id
+           ) do
         %{"_id" => _} -> :ok
         error -> {:error, {:opensearch_index, chunk.id, error}}
       end

--- a/lib/cake/documents/cluster.ex
+++ b/lib/cake/documents/cluster.ex
@@ -12,7 +12,7 @@ defmodule Cake.Documents.Cluster do
   def build_mapping(schema) do
     embedding = %{
       type: "knn_vector",
-      dimension: 1536,
+      dimension: Application.fetch_env!(:cake, :default_embedding_dimension),
       method: %{
         name: "hnsw",
         space_type: "cosinesimil",
@@ -61,8 +61,19 @@ defmodule Cake.Documents.Cluster do
     existing_indices = get_existing_indices()
 
     # Create both indices
-    _ = create_index_if_missing(existing_indices, "docs", Cake.Documents.ParsedDocument)
-    _ = create_index_if_missing(existing_indices, "chunks_of_books", Cake.Books.Chunk)
+    _ =
+      create_index_if_missing(
+        existing_indices,
+        Cake.Documents.ParsedDocument.index_name(),
+        Cake.Documents.ParsedDocument
+      )
+
+    _ =
+      create_index_if_missing(
+        existing_indices,
+        Cake.Books.ParsedBook.index_name(),
+        Cake.Books.Chunk
+      )
   end
 
   defp get_existing_indices() do

--- a/lib/cake/documents/hexdocs.ex
+++ b/lib/cake/documents/hexdocs.ex
@@ -8,6 +8,12 @@ defmodule Cake.Documents.Hexdocs do
 
   alias Cake.Documents.Hexdocs.Hexdoc
 
+  @source_repo "https://github.com/elixir-lang/elixir.git"
+
+  @doc "Git repository URL for Elixir core source, used by both download and ingestion paths."
+  @spec source_repo() :: String.t()
+  def source_repo, do: @source_repo
+
   @doc """
   Returns all hexdocs from the passed Elixir version.
   """

--- a/lib/cake/documents/hexdocs/downloads.ex
+++ b/lib/cake/documents/hexdocs/downloads.ex
@@ -8,7 +8,7 @@ defmodule Cake.Documents.Hexdocs.Downloads do
   @spec clone_and_get_module_paths(String.t()) :: [String.t()]
   def clone_and_get_module_paths(version) do
     _ = File.mkdir_p(@dir)
-    _ = System.cmd("git", ["clone", "https://github.com/elixir-lang/elixir.git", @dir], env: [])
+    _ = System.cmd("git", ["clone", Cake.Documents.Hexdocs.source_repo(), @dir], env: [])
     _ = System.cmd("git", ["checkout v#{version}"], env: [])
 
     "elixir/lib/elixir/lib"

--- a/lib/cake/documents/hexdocs/pipeline.ex
+++ b/lib/cake/documents/hexdocs/pipeline.ex
@@ -33,7 +33,7 @@ defmodule Cake.Documents.Hexdocs.Pipeline do
              "-b",
              "v#{version}",
              "--single-branch",
-             "https://github.com/elixir-lang/elixir.git",
+             Cake.Documents.Hexdocs.source_repo(),
              @dir
            ],
            env: []

--- a/lib/cake/documents/pipeline.ex
+++ b/lib/cake/documents/pipeline.ex
@@ -34,7 +34,6 @@ defmodule Cake.Documents.Pipeline do
   require Logger
 
   @cluster Cake.Documents.Cluster
-  @index "docs"
 
   @type version :: {integer(), integer(), integer()}
 
@@ -69,7 +68,12 @@ defmodule Cake.Documents.Pipeline do
              ctx
            ),
          opensearch_docs_stream <-
-           Pipelines.add_to_opensearch(docs_with_embeddings_stream, @index, @cluster, ctx),
+           Pipelines.add_to_opensearch(
+             docs_with_embeddings_stream,
+             ParsedDocument.index_name(),
+             @cluster,
+             ctx
+           ),
          :ok <- Stream.run(opensearch_docs_stream) do
       {:ok, source_pipeline.success_message(ctx)}
     else
@@ -158,9 +162,11 @@ defmodule Cake.Documents.Pipeline do
         doc
       end)
     else
+      index = ParsedDocument.index_name()
+
       docs_with_embeddings_stream
       |> Task.async_stream(
-        &Snap.Document.update(@cluster, @index, %{doc: &1, doc_as_upsert: true}, &1.id),
+        &Snap.Document.update(@cluster, index, %{doc: &1, doc_as_upsert: true}, &1.id),
         max_concurrency: 5,
         timeout: 5_000,
         on_timeout: :kill_task
@@ -186,7 +192,7 @@ defmodule Cake.Documents.Pipeline do
     do: Logger.warning("Could not insert document. Changeset: #{inspect(changeset)}")
 
   defp handle_opensearch_response(%{"_id" => id}),
-    do: Logger.info("Document #{id} created in #{@index}")
+    do: Logger.info("Document #{id} created in #{ParsedDocument.index_name()}")
 
   # Cake.Documents.Pipeline.batch_embed(:openai, Cake.Documents.Hexdocs.Pipeline, "text-embedding-ada-002", "1.18.3")
   # Need some way of passing parsed docs out one at a time to be persisted to Opensearch
@@ -318,7 +324,12 @@ defmodule Cake.Documents.Pipeline do
     if Application.get_env(:cake, :skip_opensearch, false) do
       :ok
     else
-      case Snap.Document.update(@cluster, @index, %{doc: doc, doc_as_upsert: true}, doc.id) do
+      case Snap.Document.update(
+             @cluster,
+             ParsedDocument.index_name(),
+             %{doc: doc, doc_as_upsert: true},
+             doc.id
+           ) do
         %{"_id" => _} -> :ok
         error -> {:error, {:opensearch_index, error}}
       end

--- a/lib/cake/search/open_search.ex
+++ b/lib/cake/search/open_search.ex
@@ -17,7 +17,6 @@ defmodule Cake.Search.OpenSearch do
 
   alias Cake.Search.Query
 
-  # TODO make these defaults into config vars
   @default_size 30
   @default_k 30
   @default_ef_search 256
@@ -136,6 +135,19 @@ defmodule Cake.Search.OpenSearch do
     Snap.Search.search(cluster, index, Query.to_query_map(query))
   end
 
+  @doc false
+  @spec build_query_for_test(
+          :keyword | :vector | :hybrid,
+          String.t(),
+          String.t(),
+          [float()] | nil,
+          keyword(),
+          [String.t()]
+        ) :: Query.t()
+  def build_query_for_test(search_type, index, keywords, embedding, opts, default_fields) do
+    build_query(search_type, index, keywords, embedding, opts, default_fields)
+  end
+
   defp build_query(:keyword, index, keywords, _embedding, opts, default_fields) do
     fields = Keyword.get(opts, :fields, default_fields)
     size = Keyword.get(opts, :size, @default_size)
@@ -145,10 +157,11 @@ defmodule Cake.Search.OpenSearch do
   defp build_query(:vector, index, _keywords, embedding, opts, _default_fields) do
     k = Keyword.get(opts, :k, @default_k)
     size = Keyword.get(opts, :size, @default_size)
+    ef_search = Keyword.get(opts, :ef_search, @default_ef_search)
 
     index
     |> Query.new(size: size)
-    |> Query.knn("embedding", embedding, k)
+    |> Query.knn("embedding", embedding, k, ef_search: ef_search)
   end
 
   defp build_query(:hybrid, index, keywords, embedding, opts, default_fields) do
@@ -156,10 +169,11 @@ defmodule Cake.Search.OpenSearch do
     size = Keyword.get(opts, :size, @default_size)
     k = Keyword.get(opts, :k, @default_k)
     keyword_weight = Keyword.get(opts, :keyword_weight, @default_keyword_weight)
+    ef_search = Keyword.get(opts, :ef_search, @default_ef_search)
     base = Query.new(index, size: size)
 
     base
-    |> Query.knn("embedding", embedding, k)
+    |> Query.knn("embedding", embedding, k, ef_search: ef_search)
     |> Query.match(keywords, fields, boost: keyword_weight)
   end
 end

--- a/lib/cake/search/query.ex
+++ b/lib/cake/search/query.ex
@@ -43,11 +43,25 @@ defmodule Cake.Search.Query do
     }
   end
 
-  @doc "Appends a knn clause to `must`."
-  @spec knn(t(), String.t(), [float()], pos_integer()) :: t()
-  def knn(%__MODULE__{} = query, field, vector, k)
+  @doc """
+  Appends a knn clause to `must`.
+
+  Accepts `:ef_search` to set OpenSearch's per-query KNN search depth via
+  `method_parameters.ef_search`. Higher values trade latency for recall.
+  """
+  @spec knn(t(), String.t(), [float()], pos_integer(), keyword()) :: t()
+  def knn(%__MODULE__{} = query, field, vector, k, opts \\ [])
       when is_binary(field) and is_list(vector) and is_integer(k) and k > 0 do
-    clause = %{"knn" => %{field => %{"vector" => vector, "k" => k}}}
+    embedding_clause =
+      case Keyword.get(opts, :ef_search) do
+        nil ->
+          %{"vector" => vector, "k" => k}
+
+        ef when is_integer(ef) and ef > 0 ->
+          %{"vector" => vector, "k" => k, "method_parameters" => %{"ef_search" => ef}}
+      end
+
+    clause = %{"knn" => %{field => embedding_clause}}
     %{query | must: [clause | query.must]}
   end
 

--- a/lib/cake_web/live/chat_live.ex
+++ b/lib/cake_web/live/chat_live.ex
@@ -10,9 +10,9 @@ defmodule CakeWeb.ChatLive do
       id: conversation_id,
       search: Cake.Search.OpenSearch,
       reply_to: self(),
-      embedder: "text-embedding-ada-002",
-      response_model: "gpt-4o-mini",
-      provider: :openai,
+      embedder: Application.fetch_env!(:cake, :default_embedding_model),
+      response_model: Application.fetch_env!(:cake, :default_response_model),
+      provider: Application.fetch_env!(:cake, :default_provider),
       gds: Cake.Books.ParsedBook
     }
 

--- a/lib/cake_web/live/search_live.ex
+++ b/lib/cake_web/live/search_live.ex
@@ -33,8 +33,12 @@ defmodule CakeWeb.SearchLive do
   end
 
   defp run_search(query) do
+    embeddings_module = Application.get_env(:cake, :embeddings_module, Cake.Embeddings)
+    provider = Application.fetch_env!(:cake, :default_provider)
+    model = Application.fetch_env!(:cake, :default_embedding_model)
+
     with {:ok, %{attrs: %{embedding: embedding}}} <-
-           Cake.Embeddings.embed(:openai, %{input: query}, "text-embedding-ada-002"),
+           embeddings_module.embed(provider, %{input: query}, model),
          {:ok, chunks} <-
            Cake.Search.OpenSearch.search_chunks_with_context(
              :hybrid,

--- a/test/cake/documents/cluster_test.exs
+++ b/test/cake/documents/cluster_test.exs
@@ -1,0 +1,32 @@
+defmodule Cake.Documents.ClusterTest do
+  use ExUnit.Case, async: false
+
+  alias Cake.Documents.Cluster
+
+  describe "build_mapping/1" do
+    test "uses :default_embedding_dimension from config for the knn_vector field" do
+      original = Application.get_env(:cake, :default_embedding_dimension)
+      Application.put_env(:cake, :default_embedding_dimension, 3072)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:cake, :default_embedding_dimension)
+        else
+          Application.put_env(:cake, :default_embedding_dimension, original)
+        end
+      end)
+
+      mapping = Cluster.build_mapping(Cake.Books.Chunk)
+
+      assert get_in(mapping, [:mappings, :properties, :embedding, :dimension]) == 3072
+    end
+
+    test "defaults to 1536 (matches text-embedding-ada-002 / 3-small) when config is set" do
+      Application.put_env(:cake, :default_embedding_dimension, 1536)
+
+      mapping = Cluster.build_mapping(Cake.Books.Chunk)
+
+      assert get_in(mapping, [:mappings, :properties, :embedding, :dimension]) == 1536
+    end
+  end
+end

--- a/test/cake/search/open_search_test.exs
+++ b/test/cake/search/open_search_test.exs
@@ -2,6 +2,7 @@ defmodule Cake.Search.OpenSearchTest do
   use ExUnit.Case, async: false
 
   alias Cake.Search.OpenSearch
+  alias Cake.Search.Query
   alias Cake.Support.FixtureGDS
 
   describe "default accessors" do
@@ -23,6 +24,56 @@ defmodule Cake.Search.OpenSearchTest do
 
     test "default_expand_offset/0" do
       assert OpenSearch.default_expand_offset() == 2
+    end
+  end
+
+  describe "build_query/6 plumbs :ef_search through to the knn clause" do
+    test ":vector reflects the :ef_search opt in the produced query map" do
+      query =
+        OpenSearch.build_query_for_test(
+          :vector,
+          "fixture_index",
+          "kw",
+          [0.1, 0.2],
+          [ef_search: 128],
+          ["body"]
+        )
+
+      assert %Query{must: [knn_clause]} = query
+      assert knn_clause["knn"]["embedding"]["method_parameters"] == %{"ef_search" => 128}
+    end
+
+    test ":hybrid reflects the :ef_search opt in the produced query map" do
+      query =
+        OpenSearch.build_query_for_test(
+          :hybrid,
+          "fixture_index",
+          "kw",
+          [0.1, 0.2],
+          [ef_search: 64],
+          ["body"]
+        )
+
+      assert %Query{must: [knn_clause]} = query
+      assert knn_clause["knn"]["embedding"]["method_parameters"] == %{"ef_search" => 64}
+    end
+
+    test ":vector falls back to default_ef_search when no opt is given" do
+      query =
+        OpenSearch.build_query_for_test(
+          :vector,
+          "fixture_index",
+          "kw",
+          [0.1, 0.2],
+          [],
+          ["body"]
+        )
+
+      assert %Query{must: [knn_clause]} = query
+
+      assert knn_clause["knn"]["embedding"]["method_parameters"] == %{
+               "ef_search" => OpenSearch.default_ef_search()
+             }
     end
   end
 

--- a/test/cake/search/query_test.exs
+++ b/test/cake/search/query_test.exs
@@ -45,6 +45,29 @@ defmodule Cake.Search.QueryTest do
 
       assert length(query.must) == 2
     end
+
+    test "embeds method_parameters.ef_search when :ef_search opt is given" do
+      vector = [0.1, 0.2]
+      query = Query.knn(Query.new("docs"), "embedding", vector, 10, ef_search: 128)
+
+      assert [clause] = query.must
+
+      assert clause == %{
+               "knn" => %{
+                 "embedding" => %{
+                   "vector" => vector,
+                   "k" => 10,
+                   "method_parameters" => %{"ef_search" => 128}
+                 }
+               }
+             }
+    end
+
+    test "omits method_parameters when :ef_search is not given" do
+      query = Query.knn(Query.new("docs"), "embedding", [0.1], 10)
+      assert [clause] = query.must
+      refute Map.has_key?(clause["knn"]["embedding"], "method_parameters")
+    end
   end
 
   describe "match/4" do

--- a/test/cake_web/live/chat_live_test.exs
+++ b/test/cake_web/live/chat_live_test.exs
@@ -39,4 +39,29 @@ defmodule CakeWeb.ChatLiveTest do
       assert render(lv) =~ "Cake Chat"
     end
   end
+
+  describe "configurable defaults" do
+    test "passes :default_embedding_model, :default_response_model, and :default_provider " <>
+           "from application config to the spawned Conversation",
+         %{conn: conn} do
+      Application.put_env(:cake, :default_embedding_model, "test-embedder")
+      Application.put_env(:cake, :default_response_model, "test-response-model")
+      Application.put_env(:cake, :default_provider, :test_provider)
+
+      on_exit(fn ->
+        Application.delete_env(:cake, :default_embedding_model)
+        Application.delete_env(:cake, :default_response_model)
+        Application.delete_env(:cake, :default_provider)
+      end)
+
+      {:ok, lv, _html} = live(conn, ~p"/chat")
+
+      convo_pid = :sys.get_state(lv.pid).socket.assigns.convo_pid
+      convo_state = :sys.get_state(convo_pid)
+
+      assert convo_state.embedder == "test-embedder"
+      assert convo_state.response_model == "test-response-model"
+      assert convo_state.provider == :test_provider
+    end
+  end
 end

--- a/test/cake_web/live/search_live_test.exs
+++ b/test/cake_web/live/search_live_test.exs
@@ -9,7 +9,11 @@ defmodule CakeWeb.SearchLiveTest do
 
   use CakeWeb.ConnCase
 
+  import Mox
   import Phoenix.LiveViewTest
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
 
   describe "GET /search" do
     test "mounts and renders the search form", %{conn: conn} do
@@ -37,6 +41,36 @@ defmodule CakeWeb.SearchLiveTest do
 
       refute result =~ "Searching..."
       assert render(lv) =~ "Cake Search"
+    end
+  end
+
+  describe "configurable defaults" do
+    test "passes configured embeddings_module, provider, and embedding model to embed/3",
+         %{conn: conn} do
+      Application.put_env(:cake, :embeddings_module, Cake.Embeddings.Mock)
+      Application.put_env(:cake, :default_embedding_model, "test-embedder")
+      Application.put_env(:cake, :default_provider, :test_provider)
+
+      on_exit(fn ->
+        Application.delete_env(:cake, :embeddings_module)
+        Application.delete_env(:cake, :default_embedding_model)
+        Application.delete_env(:cake, :default_provider)
+      end)
+
+      test_pid = self()
+
+      expect(Cake.Embeddings.Mock, :embed, fn provider, input, model ->
+        send(test_pid, {:embed_called, provider, input, model})
+        {:error, :stop_here}
+      end)
+
+      {:ok, lv, _html} = live(conn, ~p"/search")
+
+      lv
+      |> form("form", %{"query" => "anything"})
+      |> render_submit()
+
+      assert_receive {:embed_called, :test_provider, %{input: "anything"}, "test-embedder"}, 1_000
     end
   end
 end


### PR DESCRIPTION
Removes the @index module attribute from Cake.Books.Pipeline and
Cake.Documents.Pipeline and the matching string literals from
Cake.Documents.Cluster's index-creation step. All three now read the
index name from the GDS callback (ParsedBook.index_name/0,
ParsedDocument.index_name/0), so the GDS becomes the single source of
truth and renaming an index no longer requires editing three files.

https://claude.ai/code/session_01EN1ynk6vMUBZdWmuztKhhX