### PR TITLE
Fix dialyzer: allow nil email in User.t/0

### DIFF
--- a/lib/cake/accounts/user.ex
+++ b/lib/cake/accounts/user.ex
@@ -15,7 +15,7 @@ defmodule Cake.Accounts.User do
   @type t :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: Ecto.UUID.t() | nil,
-          email: String.t(),
+          email: String.t() | nil,
           password: String.t() | nil,
           hashed_password: String.t() | nil,
           current_password: String.t() | nil,


### PR DESCRIPTION
## Summary

Fixes the dialyzer failure introduced by #156 (the typespec-tightening PR).

`Cake.Accounts.change_user_registration/2` (and friends) was tightened from `(struct(), map())` to `(User.t(), map())`. But `User.t()` declared `email: String.t()` (not nilable), while `CakeWeb.UserRegistrationLive` builds a fresh `%User{}` whose `email` is `nil`. Dialyzer rightly flagged this as a contract violation:

```
lib/cake_web/live/user_registration_live.ex:48:no_return Function mount/3 has no local return.
lib/cake_web/live/user_registration_live.ex:49:call The function call change_user_registration will not succeed.
lib/cake_web/live/user_registration_live.ex:79:call The function call change_user_registration will not succeed.
```

Make `email` `String.t() | nil` so the type matches the struct's actual values pre-validation. The other virtual/nullable fields on `User` were already nil-permitting; only `email` was overstated.

## Test plan
- [x] `mix dialyzer` — 0 errors (was 3)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` — clean (only pre-existing TODO design suggestions)
- [x] `mix format --check-formatted` — clean
- [x] `mix test --exclude integration` — 412 tests, 0 failures

https://claude.ai/code/session_01RNwd7yvbYV8b8pmgviTNzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNwd7yvbYV8b8pmgviTNzh)_