### PR TITLE
Fix silent-wrong-answer bugs (#168)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -46,3 +46,8 @@ config :cake, Cake.Generation.OpenAI,
   openai_key: "test-key-not-real",
   response_url: "http://localhost/v1/responses",
   plug: {Req.Test, Cake.Generation.OpenAI}
+
+config :cake, Cake.Embeddings,
+  openai_key: "test-key-not-real",
+  base_url: "http://localhost/v1/embeddings",
+  plug: {Req.Test, Cake.Embeddings}

--- a/lib/cake/books/chunk.ex
+++ b/lib/cake/books/chunk.ex
@@ -39,7 +39,7 @@ defmodule Cake.Books.Chunk do
           id: Ecto.UUID.t() | nil,
           text: String.t(),
           page_number: integer() | nil,
-          chunk_index: integer(),
+          chunk_index: integer() | nil,
           section_title: String.t() | nil,
           word_count: integer(),
           char_count: integer(),

--- a/lib/cake/books/pdf/pipeline.ex
+++ b/lib/cake/books/pdf/pipeline.ex
@@ -96,13 +96,15 @@ defmodule Cake.Books.Pdf.Pipeline do
 
   @spec build_chunks([PageContent.t()]) :: [Chunk.t()]
   defp build_chunks(pages) do
+    # chunk_index is intentionally left unset here: blank chunks are rejected
+    # below, so numbering them at this point would leave gaps. Persistence
+    # assigns contiguous indices over the surviving chunks (single source of
+    # truth).
     pages
-    |> Enum.with_index()
-    |> Enum.map(fn {page, index} ->
+    |> Enum.map(fn page ->
       %Chunk{
         text: page.text,
         page_number: page.page_number,
-        chunk_index: index,
         word_count: count_words(page.text),
         char_count: String.length(page.text)
       }

--- a/lib/cake/books/persistence.ex
+++ b/lib/cake/books/persistence.ex
@@ -79,7 +79,10 @@ defmodule Cake.Books.Persistence do
       |> Map.from_struct()
       |> Map.drop([:__meta__, :id, :inserted_at, :updated_at, :parsed_book])
       |> Map.put(:parsed_book_id, book_id)
-      |> Map.put_new(:chunk_index, idx)
+      # Persistence is the single source of truth for chunk_index: the parse
+      # step rejects blank chunks, so the only contiguous numbering is the one
+      # assigned here over the surviving chunks.
+      |> Map.put(:chunk_index, idx)
 
     cs = Chunk.changeset(%Chunk{}, chunk_attrs)
 

--- a/lib/cake/candidates.ex
+++ b/lib/cake/candidates.ex
@@ -56,10 +56,14 @@ defmodule Cake.Candidates do
 
   @spec expand_to_chunk_ids([String.t()], grouped()) :: [term()]
   def expand_to_chunk_ids(selected_doc_ids, candidates) do
-    lookup = Map.new(candidates)
+    # The selection form carries doc ids as strings (ChatLive builds them with
+    # to_string/1), so the lookup is keyed by the same stringified form. Keying
+    # on the raw term silently misses whenever a doc id is not already a plain
+    # string.
+    lookup = Map.new(candidates, fn {doc_id, chunks} -> {to_string(doc_id), chunks} end)
 
     Enum.flat_map(selected_doc_ids, fn doc_id ->
-      chunks = Map.get(lookup, doc_id, [])
+      chunks = Map.get(lookup, to_string(doc_id), [])
       Enum.map(chunks, fn {chunk, _scores} -> Citable.metadata(chunk).id end)
     end)
   end

--- a/lib/cake/documents/parsed_document.ex
+++ b/lib/cake/documents/parsed_document.ex
@@ -110,8 +110,8 @@ defmodule Cake.Documents.ParsedDocument do
       :version,
       :package,
       # :title,
-      :url
-      # text:
+      :url,
+      :text
     ])
     |> sanitize_text_fields()
   end

--- a/lib/cake/embeddings.ex
+++ b/lib/cake/embeddings.ex
@@ -10,16 +10,20 @@ defmodule Cake.Embeddings do
 
   # This needs a spec defining the different error tuples it can return
   @impl Cake.Embeddings.Behaviour
-  def embed(:openai, %{input: input}, model) do
-    [openai_key: api_key, base_url: url] = Application.get_env(:cake, __MODULE__)
+  def embed(:openai, %{input: input} = payload, model) do
+    config = Application.get_env(:cake, __MODULE__, [])
+    api_key = Keyword.fetch!(config, :openai_key)
+    url = Keyword.fetch!(config, :base_url)
+
+    request_opts =
+      maybe_put_plug(
+        [url: url, json: %{model: model, input: input}, auth: {:bearer, api_key}],
+        config
+      )
 
     # Later on, there should probably be multiple function heads of "embed", but
     # extract the following to its own re-used handle_response function.
-    case Req.post(
-           url: url,
-           json: %{model: model, input: input},
-           auth: {:bearer, api_key}
-         ) do
+    case Req.post(request_opts) do
       {:ok,
        %Req.Response{
          status: 200,
@@ -37,13 +41,27 @@ defmodule Cake.Embeddings do
 
         attrs = %{embedding: embedding}
 
-        {:ok, %{usage: usage, input: input, attrs: attrs}}
+        # Thread the caller-provided struct back through untouched: the
+        # Documents pipeline passes the ParsedDocument it is embedding and reads
+        # it back to persist the embedding. Callers that pass no struct (Books)
+        # get nil and ignore it.
+        {:ok, %{usage: usage, struct: Map.get(payload, :struct), attrs: attrs}}
 
       {:ok, %Req.Response{status: code}} ->
         {:error, "#{__MODULE__}  Transport layer error: #{code}"}
 
       {:error, %{reason: reason}} ->
         {:error, "#{__MODULE__}  Application layer error: #{reason}"}
+    end
+  end
+
+  # A `:plug` key in the config (set only in config/test.exs) routes HTTP through
+  # Req.Test for stubbed responses, mirroring Cake.Generation.OpenAI. Production
+  # config omits it.
+  defp maybe_put_plug(opts, config) do
+    case Keyword.get(config, :plug) do
+      nil -> opts
+      plug -> Keyword.put(opts, :plug, plug)
     end
   end
 end

--- a/lib/cake/embeddings/behaviour.ex
+++ b/lib/cake/embeddings/behaviour.ex
@@ -8,7 +8,7 @@ defmodule Cake.Embeddings.Behaviour do
 
   @type embedding_result :: %{
           usage: map(),
-          parsed_document: struct(),
+          struct: struct() | nil,
           attrs: %{embedding: [float()]}
         }
 

--- a/test/cake/books/persistence_test.exs
+++ b/test/cake/books/persistence_test.exs
@@ -1,0 +1,64 @@
+defmodule Cake.Books.PersistenceTest do
+  @moduledoc """
+  Write-path coverage for `Cake.Books.Persistence`, focused on the chunk_index
+  contract (#168).
+
+  Persistence is the single source of truth for `chunk_index`: it assigns
+  contiguous indices at persist time, regardless of any index the parse step
+  put on the input chunks. Contiguity is what `expand_with_neighbors`/
+  `within_pages` rely on, so gaps (from blank-chunk rejection upstream) must
+  not survive into the database.
+  """
+
+  use Cake.DataCase, async: true
+
+  alias Cake.Books.Chunk
+  alias Cake.Books.ParsedBook
+  alias Cake.Books.Persistence
+
+  defp book(attrs \\ %{}) do
+    Map.merge(
+      %ParsedBook{
+        title: "T",
+        source_file_path: "/tmp/x.pdf",
+        source_format: "pdf",
+        file_hash: "hash-#{System.unique_integer([:positive])}",
+        file_size: 10,
+        total_pages: 3,
+        word_count: 9,
+        parsed_at: DateTime.truncate(DateTime.utc_now(), :second),
+        embedding_status: :pending
+      },
+      attrs
+    )
+  end
+
+  defp chunk(text, overrides \\ %{}) do
+    Map.merge(
+      %Chunk{text: text, word_count: 1, char_count: String.length(text), page_number: 1},
+      overrides
+    )
+  end
+
+  describe "persist_books_and_chunks/1 chunk_index" do
+    test "assigns contiguous indices, overriding any indices on the input chunks" do
+      chunks = [
+        chunk("a", %{chunk_index: 5}),
+        chunk("b", %{chunk_index: 3}),
+        chunk("c", %{chunk_index: 9})
+      ]
+
+      assert {:ok, {_book, persisted}} = Persistence.persist_books_and_chunks({book(), chunks})
+
+      assert persisted |> Enum.map(& &1.chunk_index) |> Enum.sort() == [0, 1, 2]
+    end
+
+    test "assigns indices even when the input chunks carry none" do
+      chunks = [chunk("a"), chunk("b")]
+
+      assert {:ok, {_book, persisted}} = Persistence.persist_books_and_chunks({book(), chunks})
+
+      assert persisted |> Enum.map(& &1.chunk_index) |> Enum.sort() == [0, 1]
+    end
+  end
+end

--- a/test/cake/candidates_test.exs
+++ b/test/cake/candidates_test.exs
@@ -1,0 +1,83 @@
+defmodule Cake.CandidatesTest do
+  @moduledoc """
+  Unit coverage for `Cake.Candidates`, the module that groups scored search
+  units by document and maps a manual selection back to chunk ids.
+
+  The `expand_to_chunk_ids/2` tests pin the contract that the selection form
+  relies on: `ChatLive` builds the form's doc ids via `to_string(doc_id)`, so
+  the lookup must key on the same stringified form. Keying on the raw term
+  silently yields no chunks when the id is not already a plain string (#168).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Cake.Factory, only: [chunk_metadata: 1]
+
+  alias Cake.Candidates
+  alias Cake.Citable
+  alias Cake.Test.ConvoChunk
+
+  defp chunk(meta_overrides) do
+    %ConvoChunk{metadata: chunk_metadata(meta_overrides)}
+  end
+
+  defp scored(meta_overrides), do: {chunk(meta_overrides), %{score: 1.0}}
+
+  describe "group_by_document/1" do
+    test "groups scored chunks by source_ref, preserving first-seen document order" do
+      candidates = [
+        scored(id: "a", source_ref: "doc-1"),
+        scored(id: "b", source_ref: "doc-2"),
+        scored(id: "c", source_ref: "doc-1")
+      ]
+
+      assert [{"doc-1", doc1_chunks}, {"doc-2", doc2_chunks}] =
+               Candidates.group_by_document(candidates)
+
+      assert doc1_chunks |> Enum.map(fn {ch, _} -> Citable.metadata(ch).id end) |> Enum.sort() ==
+               ["a", "c"]
+
+      assert [{ch, _}] = doc2_chunks
+      assert Citable.metadata(ch).id == "b"
+    end
+
+    test "falls back to the chunk id when source_ref is nil" do
+      assert [{"only-id", _}] =
+               Candidates.group_by_document([scored(id: "only-id", source_ref: nil)])
+    end
+  end
+
+  describe "expand_to_chunk_ids/2" do
+    test "matches form-stringified ids against non-string candidate keys" do
+      # The grouped key is an integer (a non-string term); the form submits "1".
+      candidates = [{1, [scored(id: "chunk-a", source_ref: nil)]}]
+
+      assert Candidates.expand_to_chunk_ids(["1"], candidates) == ["chunk-a"]
+    end
+
+    test "returns chunk ids only for the selected documents" do
+      candidates = [
+        {"doc-1", [scored(id: "a", source_ref: "doc-1")]},
+        {"doc-2", [scored(id: "b", source_ref: "doc-2")]}
+      ]
+
+      assert Candidates.expand_to_chunk_ids(["doc-1"], candidates) == ["a"]
+    end
+
+    test "yields no chunks for an unknown doc id" do
+      candidates = [{"doc-1", [scored(id: "a", source_ref: "doc-1")]}]
+      assert Candidates.expand_to_chunk_ids(["nope"], candidates) == []
+    end
+  end
+
+  describe "all_chunk_ids/1" do
+    test "flattens every chunk id across all documents" do
+      candidates = [
+        {"doc-1", [scored(id: "a", source_ref: "doc-1")]},
+        {"doc-2", [scored(id: "b", source_ref: "doc-2")]}
+      ]
+
+      assert Candidates.all_chunk_ids(candidates) == ["a", "b"]
+    end
+  end
+end

--- a/test/cake/embeddings_test.exs
+++ b/test/cake/embeddings_test.exs
@@ -20,13 +20,18 @@ defmodule Cake.EmbeddingsTest do
   Live OpenAI calls are out of scope for unit tests and will be tagged
   `:integration` per #109.
 
+  ## HTTP stubbing
+
+  Successful responses are now exercised via `Req.Test`: `embed/3` reads an
+  optional `:plug` from its config block (set to `{Req.Test, Cake.Embeddings}`
+  in `config/test.exs`), mirroring `Cake.Generation.OpenAI`. The success test
+  below stubs the OpenAI embeddings response shape and asserts the result
+  threads the caller's struct through.
+
   ## What this file does NOT test
 
-  - Successful HTTP responses — would require an HTTP stub server
-    (Bypass / Req.Test plug). Deferred until a refactor lets `embed/3`
-    accept request options, or a test harness module is introduced.
   - The OpenAI response-shape unhappy paths beyond transport failure —
-    same reason.
+    would require additional stubbed responses; deferred.
   """
 
   use ExUnit.Case, async: false
@@ -61,6 +66,29 @@ defmodule Cake.EmbeddingsTest do
       assert is_binary(message)
       assert message =~ "Cake.Embeddings"
       assert message =~ "Application layer error"
+    end
+  end
+
+  describe "embed/3 success" do
+    test "threads the caller's struct through and returns the embedding attrs" do
+      Req.Test.stub(Cake.Embeddings, fn conn ->
+        Req.Test.json(conn, %{
+          "data" => [%{"embedding" => [0.1, 0.2, 0.3], "index" => 0}],
+          "usage" => %{"prompt_tokens" => 5, "total_tokens" => 5}
+        })
+      end)
+
+      passed = ~D[2025-01-01]
+
+      assert {:ok, result} =
+               Embeddings.embed(
+                 :openai,
+                 %{input: "hello", struct: passed},
+                 "text-embedding-ada-002"
+               )
+
+      assert result.struct == passed
+      assert result.attrs == %{embedding: [0.1, 0.2, 0.3]}
     end
   end
 

--- a/test/cake/parsed_document_test.exs
+++ b/test/cake/parsed_document_test.exs
@@ -47,6 +47,13 @@ defmodule Cake.ParsedDocumentTest do
       assert {:error, %Ecto.Changeset{}} = ParsedDocuments.create_parsed_document(@invalid_attrs)
     end
 
+    test "create_parsed_documents/1 without text returns an error requiring text" do
+      attrs = %{source: "s", version: "v", package: "p", url: "u", title: "t", core: true}
+
+      assert {:error, changeset} = ParsedDocuments.create_parsed_document(attrs)
+      assert "can't be blank" in errors_on(changeset).text
+    end
+
     test "update_parsed_documents/2 with valid data updates the parsed_documents" do
       parsed_documents = parsed_documents_fixture()
 


### PR DESCRIPTION
Closes the four surgical fixes in #168 — the correctness bugs that silently produce wrong answers with no error surfaced. One commit per checkbox.

## What's fixed

- **Manual document selection silently yielding `[]`** — `ChatLive` builds the selection form's doc ids with `to_string/1`, but `Candidates.expand_to_chunk_ids/2` keyed its lookup on the raw doc id. When an id isn't already a plain string the keys never matched, so a manual selection ran the turn with no chunks. The lookup now keys on the stringified id. Adds the first tests for `Cake.Candidates`.
- **`chunk_index` gaps from two competing sources of truth** — the PDF pipeline numbered pages *before* rejecting blank chunks (leaving gaps), and persistence re-derived the index but used `Map.put_new`, keeping the gappy value. Gaps break `expand_with_neighbors`/`within_pages`. Persistence is now the sole authority and assigns contiguous indices via `Map.put`; the pipeline no longer sets `chunk_index` (`Chunk.chunk_index` is `integer() | nil` until persisted). Adds the first tests for `Cake.Books.Persistence`.
- **Title-only documents persisting and "embedding"** — `:text` was commented out of `ParsedDocument`'s `validate_required`. Restored.
- **`Embeddings` result contract wrong on both ends** — the behaviour declared `parsed_document:`, the producer returned `%{usage:, input:, attrs:}`, and the Documents consumer reads `%{struct:, attrs:}`. The real producer dropped the struct the caller passed, so the Documents embed path only worked under the mock. The producer now threads the caller's struct through and the type is corrected to `%{usage:, struct:, attrs:}`. `embed/3` also reads its config with `Keyword.fetch!` and honours an optional `:plug` (mirroring `Cake.Generation.OpenAI`), enabling a `Req.Test`-stubbed success-path test.

## Scope note

The original fifth item in #168 — advancing `ParsedBook.embedding_status` through its lifecycle — was split out into **#172**, because it requires restructuring the (currently untested) Books embed stream rather than a one-line fix. #172 is blocked on **#171** (the Books path must be under test first).

## Verification

Full pre-push gate from `CLAUDE.md`, all green:

- `mix compile --warnings-as-errors` — clean
- `mix test --exclude integration` — 30 properties, 434 tests, 0 failures
- `mix credo --strict` — 0 issues (8 pre-existing TODO design suggestions unchanged)
- `mix format --check-formatted` — clean

Each fix was written test-first: tests were confirmed red against the bug, then green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B97zWC6hpyKwR7A3xf9mUT)_