### PR TITLE
Security: auth on routes, download path-traversal defense, no leaked errors (#166)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,11 @@ config :cake, Cake.Conversation,
   response_model: "gpt-4o-mini",
   provider: :openai
 
+# Filesystem root that book downloads must resolve under. BooksController
+# refuses to serve any ParsedBook whose source_file_path escapes this directory,
+# so a poisoned/buggy path in the DB can't be used to read arbitrary files.
+config :cake, :books_download_root, Path.expand("../assets/static", __DIR__)
+
 # Configures the mailer
 #
 # By default it uses the "Local" adapter which stores the emails

--- a/config/test.exs
+++ b/config/test.exs
@@ -46,3 +46,6 @@ config :cake, Cake.Generation.OpenAI,
   openai_key: "test-key-not-real",
   response_url: "http://localhost/v1/responses",
   plug: {Req.Test, Cake.Generation.OpenAI}
+
+# The books-controller tests stage fixture files under the system temp dir.
+config :cake, :books_download_root, System.tmp_dir!()

--- a/lib/cake_web/controllers/books_controller.ex
+++ b/lib/cake_web/controllers/books_controller.ex
@@ -16,25 +16,42 @@ defmodule CakeWeb.BooksController do
              limit: 1
          ) do
       nil ->
-        conn
-        |> put_status(:not_found)
-        |> text("Book not found")
+        not_found(conn, "Book not found")
 
       %{source_file_path: path} ->
-        if File.exists?(path) do
-          filename = Path.basename(path)
-
-          conn
-          |> put_resp_header(
-            "content-disposition",
-            ~s(attachment; filename="#{filename}")
-          )
-          |> send_file(200, path)
-        else
-          conn
-          |> put_status(:not_found)
-          |> text("File not found on disk")
-        end
+        serve_book(conn, path)
     end
+  end
+
+  # Defense in depth: the path came from a ParsedBook row, but refuse to serve
+  # anything that resolves outside the configured books root so a poisoned or
+  # buggy stored path can't be used to read arbitrary files. The root check
+  # runs before any filesystem access, and an out-of-root path is reported as
+  # "Book not found" so existence is not revealed.
+  defp serve_book(conn, path) do
+    cond do
+      not within_root?(path) -> not_found(conn, "Book not found")
+      not File.exists?(path) -> not_found(conn, "File not found on disk")
+      true -> send_book(conn, path)
+    end
+  end
+
+  defp send_book(conn, path) do
+    conn
+    |> put_resp_header("content-disposition", ~s(attachment; filename="#{Path.basename(path)}"))
+    |> send_file(200, path)
+  end
+
+  defp not_found(conn, message) do
+    conn
+    |> put_status(:not_found)
+    |> text(message)
+  end
+
+  defp within_root?(path) do
+    root = Path.expand(Application.fetch_env!(:cake, :books_download_root))
+    expanded = Path.expand(path)
+
+    expanded == root or String.starts_with?(expanded, root <> "/")
   end
 end

--- a/lib/cake_web/live/chat_live.ex
+++ b/lib/cake_web/live/chat_live.ex
@@ -6,6 +6,8 @@ defmodule CakeWeb.ChatLive do
   alias CakeWeb.ChatLive.QuestionForm
   alias CakeWeb.ChatLive.SelectionForm
 
+  require Logger
+
   @spec mount(map(), map(), Phoenix.LiveView.Socket.t()) ::
           {:ok, Phoenix.LiveView.Socket.t()}
   def mount(_params, _session, socket) do
@@ -102,18 +104,25 @@ defmodule CakeWeb.ChatLive do
   end
 
   def handle_info({:error, reason}, socket) do
-    {:noreply,
-     socket
-     |> append_message(%{role: :assistant, text: "Error: #{inspect(reason)}"})
-     |> reset_to_idle()}
-  end
+    Logger.error("ChatLive conversation error: #{inspect(reason)}")
 
-  def handle_info({:DOWN, _ref, :process, _pid, reason}, socket) do
     {:noreply,
      socket
      |> append_message(%{
        role: :assistant,
-       text: "Error: conversation process crashed (#{inspect(reason)})"
+       text: "Sorry, something went wrong while answering your question. Please try again."
+     })
+     |> reset_to_idle()}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, reason}, socket) do
+    Logger.error("ChatLive conversation process crashed: #{inspect(reason)}")
+
+    {:noreply,
+     socket
+     |> append_message(%{
+       role: :assistant,
+       text: "Sorry, the conversation ended unexpectedly. Please start a new question."
      })
      |> reset_to_idle()}
   end

--- a/lib/cake_web/live/search_live.ex
+++ b/lib/cake_web/live/search_live.ex
@@ -3,6 +3,8 @@ defmodule CakeWeb.SearchLive do
 
   alias Cake.Search.Result
 
+  require Logger
+
   @spec mount(map(), map(), Phoenix.LiveView.Socket.t()) ::
           {:ok, Phoenix.LiveView.Socket.t()}
   def mount(_params, _session, socket) do
@@ -29,7 +31,13 @@ defmodule CakeWeb.SearchLive do
            assign(socket, results: results, loading: false, form: to_form(%{"query" => ""}))}
 
         {:error, error} ->
-          {:noreply, assign(socket, loading: false, error: inspect(error))}
+          Logger.error("SearchLive search failed: #{inspect(error)}")
+
+          {:noreply,
+           assign(socket,
+             loading: false,
+             error: "Search failed. Please try again."
+           )}
       end
     end
   end

--- a/lib/cake_web/router.ex
+++ b/lib/cake_web/router.ex
@@ -21,9 +21,18 @@ defmodule CakeWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
-    live "/chat", ChatLive
-    live "/search", SearchLive
+  end
+
+  scope "/", CakeWeb do
+    pipe_through [:browser, :require_authenticated_user]
+
     get "/books/download/*file_path", BooksController, :download
+
+    live_session :authenticated_app,
+      on_mount: [{CakeWeb.UserAuth, :ensure_authenticated}] do
+      live "/chat", ChatLive
+      live "/search", SearchLive
+    end
   end
 
   # Other scopes may use custom stacks.

--- a/test/cake_web/controllers/books_controller_test.exs
+++ b/test/cake_web/controllers/books_controller_test.exs
@@ -16,9 +16,30 @@ defmodule CakeWeb.BooksControllerTest do
 
   import Cake.BooksFixtures
 
+  setup :register_and_log_in_user
+
+  describe "authentication" do
+    test "redirects to the login page when the user is not authenticated" do
+      conn = get(build_conn(), ~p"/books/download/whatever.pdf")
+
+      assert redirected_to(conn) =~ "/users/log_in"
+    end
+  end
+
   describe "GET /books/download/*file_path" do
     test "returns 404 when no ParsedBook matches the requested path", %{conn: conn} do
       conn = get(conn, ~p"/books/download/no/such/book.pdf")
+
+      assert response(conn, 404) =~ "Book not found"
+    end
+
+    test "returns 404 when the stored path resolves outside the allowed root", %{conn: conn} do
+      # /etc/passwd exists on the host but is outside the books root, so even a
+      # (poisoned) ParsedBook row pointing at it must never be served.
+      outside_path = "/etc/passwd"
+      _book = parsed_book_fixture(%{source_file_path: outside_path})
+
+      conn = get(conn, ~p"/books/download/#{outside_path}")
 
       assert response(conn, 404) =~ "Book not found"
     end

--- a/test/cake_web/live/chat_live_test.exs
+++ b/test/cake_web/live/chat_live_test.exs
@@ -7,6 +7,15 @@ defmodule CakeWeb.ChatLiveTest do
   alias Cake.Search.Provenance
   alias Cake.Search.Result
 
+  setup :register_and_log_in_user
+
+  describe "authentication" do
+    test "redirects to the login page when the user is not authenticated" do
+      assert {:error, {:redirect, %{to: path}}} = live(build_conn(), ~p"/chat")
+      assert path =~ "/users/log_in"
+    end
+  end
+
   describe "mount" do
     test "renders the chat page in idle state", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/chat")
@@ -100,14 +109,15 @@ defmodule CakeWeb.ChatLiveTest do
       assert html =~ "A preview snippet"
     end
 
-    test ":error appends error message and returns to idle", %{conn: conn} do
+    test ":error shows a safe message without leaking the reason and returns to idle",
+         %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/chat")
 
       broadcast_to_view(view, {:error, :some_failure})
 
       html = render(view)
-      assert html =~ "Error:"
-      assert html =~ "some_failure"
+      assert html =~ "something went wrong"
+      refute html =~ "some_failure"
       refute html =~ "Thinking..."
     end
   end
@@ -129,14 +139,14 @@ defmodule CakeWeb.ChatLiveTest do
   end
 
   describe "conversation process crash" do
-    test "DOWN message shows crash error", %{conn: conn} do
+    test "DOWN message shows a safe message without leaking the crash reason", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/chat")
 
       send(view.pid, {:DOWN, make_ref(), :process, self(), :boom})
 
       html = render(view)
-      assert html =~ "conversation process crashed"
-      assert html =~ "boom"
+      assert html =~ "ended unexpectedly"
+      refute html =~ "boom"
     end
   end
 

--- a/test/cake_web/live/search_live_test.exs
+++ b/test/cake_web/live/search_live_test.exs
@@ -11,6 +11,15 @@ defmodule CakeWeb.SearchLiveTest do
 
   import Phoenix.LiveViewTest
 
+  setup :register_and_log_in_user
+
+  describe "authentication" do
+    test "redirects to the login page when the user is not authenticated" do
+      assert {:error, {:redirect, %{to: path}}} = live(build_conn(), ~p"/search")
+      assert path =~ "/users/log_in"
+    end
+  end
+
   describe "GET /search" do
     test "mounts and renders the search form", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"/search")
@@ -37,6 +46,31 @@ defmodule CakeWeb.SearchLiveTest do
 
       refute result =~ "Searching..."
       assert render(lv) =~ "Cake Search"
+    end
+  end
+
+  describe "error handling" do
+    test "shows a generic message without leaking the internal error", %{conn: conn} do
+      Application.put_env(:cake, Cake.Embeddings,
+        openai_key: "test-key",
+        base_url: "http://localhost/v1/embeddings",
+        req_options: [plug: {Req.Test, Cake.Embeddings}]
+      )
+
+      on_exit(fn -> Application.delete_env(:cake, Cake.Embeddings) end)
+
+      {:ok, lv, _} = live(conn, ~p"/search")
+
+      Req.Test.stub(Cake.Embeddings, fn c -> Plug.Conn.send_resp(c, 500, "boom") end)
+      Req.Test.allow(Cake.Embeddings, self(), lv.pid)
+
+      html =
+        lv
+        |> form("form", %{"query" => "hello"})
+        |> render_submit()
+
+      refute html =~ "Transport layer error"
+      assert html =~ "Search failed"
     end
   end
 end


### PR DESCRIPTION
Closes #166 — the three high-severity security gaps. One commit per checkbox.

## What's fixed

- **Unauthenticated routes** (`7b22419`) — `/chat`, `/search`, and `/books/download/*file_path` sat in the open browser scope. Moved them behind `:require_authenticated_user` (plus an `:ensure_authenticated` `live_session` for the LiveViews), so anonymous visitors are redirected to login. The public landing page (`/`) stays open.
- **Download path traversal** (`701a0ea`) — `BooksController` streamed whatever `source_file_path` a matching `ParsedBook` row held; the only guard was that the row existed, so a poisoned/buggy stored path (e.g. `/etc/passwd`) could be served. Added a configurable `:books_download_root` and a containment check that runs **before any filesystem access**; an out-of-root path is reported as "Book not found" so existence isn't revealed.
- **Leaked internal errors** (`3f26739`) — `ChatLive` rendered `inspect/1` of error and `:DOWN` crash reasons into the conversation, and `SearchLive` rendered `inspect/1` of search failures. Replaced with generic user-safe messages; the real reason is now logged server-side via `Logger`, so debuggability is preserved without exposing internals to the browser.

## The traversal bug was live

The new controller test confirmed it before the fix — it served the host's `/etc/passwd` (200) until the root check landed.

## Config note

`:books_download_root` defaults to `assets/static` (matching the ingest pipeline's example layout) and is overridden to the system temp dir in `config/test.exs` (where the controller tests stage fixtures). Set it per-environment to wherever book files actually live.

## Commit structure

The auth change necessarily touches every UI test file (they'd otherwise redirect), and each of those files also carries its item-2/item-3 test, so strict per-checkbox file isolation isn't possible. Each file is assigned to its primary checkbox; the auth `setup`/redirect assertions ride along in the per-feature test files. The PR tip is fully green.

## Verification (full pre-push gate, all green)

- `mix compile --warnings-as-errors` — clean
- `mix test --exclude integration` — 30 properties, 445 tests, 0 failures
- `mix credo` (strict) — 0 issues
- `mix format --check-formatted` — clean
- `mix coveralls` — 68.6% ≥ 65 (BooksController 100%, router 93.7%)

Behaviour-changing items were written test-first (the traversal test confirmed the vuln, then the fix; the error tests assert the reason is no longer rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B97zWC6hpyKwR7A3xf9mUT)_