### PR TITLE
Honest docs: reconcile README + CLAUDE.md with the code (#175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ tags: [claude-code, ai-instructions, conventions, quality-gates]
 date: 2026-04-15
 domain: development, ai-workflow
 source: project-maintainer
-last_verified: 2026-04-15
+last_verified: 2026-06-19
 last_reviewed: 2026-04-23 [jasper]
 ---
 
@@ -14,7 +14,7 @@ This file governs how you work on Cake. The README describes what things are and
 
 For architecture, module responsibilities, data schemas, domain model, cardinality mappings, behaviours, protocols, and the RAG loop, read the README. Do not duplicate that understanding here — reference it.
 
-*Certified accurate by caleb-bb on 2026-04-16*
+*Certified accurate by caleb-bb on 2026-06-19*
 
 ---
 
@@ -42,7 +42,7 @@ These reference files in `priv/reference/` should be loaded when the task matche
 | Write/modify public API for external consumption, design behaviours for third-party use | `library-guidelines.md` |
 | Add a new GDS, modify an existing GDS's contract, or implement `Cake.GDS` / `Cake.Promptable` / `Cake.Citable` on a schema or struct | README's "Cardinality" + "Adding a New GDS" sections; `lib/cake/gds.ex` + `lib/cake/promptable.ex` + `lib/cake/citable.ex`; one existing GDS impl (`ParsedBook` or `ParsedDocument`) as reference; `design-anti-patterns.md` |
 
-*Certified accurate by caleb-bb on 2026-04-16*
+*Certified accurate by caleb-bb on 2026-06-19*
 
 ---
 
@@ -133,7 +133,7 @@ Consult the README section "Adding a New GDS" before starting. The checklist inc
 - Add a factory via `build/1` in `test/support/factory.ex`.
 - Add the struct to the README's "Custom Structs" section.
 
-*Certified accurate by caleb-bb on 2026-04-16*
+*Certified accurate by caleb-bb on 2026-06-19*
 
 ---
 
@@ -159,7 +159,7 @@ Modules that depend on external services accept collaborator modules as argument
 
 All pipeline callbacks return `{:ok, _}` or `{:error, _}`. Stream steps use `Pipelines.detuple_with_logging/3` — never the silent `detuple/1`. Step names follow `"pipeline.step"` convention. Pipeline-fatal errors go in the `else` branch of the `with` chain in each behaviour's `ingest` function.
 
-*Certified accurate by caleb-bb on 2026-04-16*
+*Certified accurate by caleb-bb on 2026-06-19*
 
 ---
 
@@ -212,7 +212,7 @@ After completing any task that changes architecture, module boundaries, conventi
 
 **The enumeration rule:** If the README contains a list of things (behaviours, protocols, structs, implementations, pipeline implementations, etc.) and you create a new instance of that kind of thing, add it to the list. For example: if you create a new behaviour, add it to the "Behaviours and Implementations" section. If you implement a protocol for a new struct, add the implementation to the "Protocols and Implementations" section. If you create a new schema, add it to the "Custom Structs" section.
 
-*Certified accurate by caleb-bb on 2026-04-16*
+*Certified accurate by caleb-bb on 2026-06-19*
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file governs how you work on Cake. The README describes what things are and
 
 For architecture, module responsibilities, data schemas, domain model, cardinality mappings, behaviours, protocols, and the RAG loop, read the README. Do not duplicate that understanding here — reference it.
 
-*Certified accurate by caleb-bb on 2026-06-19*
+*Certified accurate by Claude on 2026-06-19*
 
 ---
 
@@ -42,7 +42,7 @@ These reference files in `priv/reference/` should be loaded when the task matche
 | Write/modify public API for external consumption, design behaviours for third-party use | `library-guidelines.md` |
 | Add a new GDS, modify an existing GDS's contract, or implement `Cake.GDS` / `Cake.Promptable` / `Cake.Citable` on a schema or struct | README's "Cardinality" + "Adding a New GDS" sections; `lib/cake/gds.ex` + `lib/cake/promptable.ex` + `lib/cake/citable.ex`; one existing GDS impl (`ParsedBook` or `ParsedDocument`) as reference; `design-anti-patterns.md` |
 
-*Certified accurate by caleb-bb on 2026-06-19*
+*Certified accurate by Claude on 2026-06-19*
 
 ---
 
@@ -133,7 +133,7 @@ Consult the README section "Adding a New GDS" before starting. The checklist inc
 - Add a factory via `build/1` in `test/support/factory.ex`.
 - Add the struct to the README's "Custom Structs" section.
 
-*Certified accurate by caleb-bb on 2026-06-19*
+*Certified accurate by Claude on 2026-06-19*
 
 ---
 
@@ -159,7 +159,7 @@ Modules that depend on external services accept collaborator modules as argument
 
 All pipeline callbacks return `{:ok, _}` or `{:error, _}`. Stream steps use `Pipelines.detuple_with_logging/3` — never the silent `detuple/1`. Step names follow `"pipeline.step"` convention. Pipeline-fatal errors go in the `else` branch of the `with` chain in each behaviour's `ingest` function.
 
-*Certified accurate by caleb-bb on 2026-06-19*
+*Certified accurate by Claude on 2026-06-19*
 
 ---
 
@@ -212,7 +212,7 @@ After completing any task that changes architecture, module boundaries, conventi
 
 **The enumeration rule:** If the README contains a list of things (behaviours, protocols, structs, implementations, pipeline implementations, etc.) and you create a new instance of that kind of thing, add it to the list. For example: if you create a new behaviour, add it to the "Behaviours and Implementations" section. If you implement a protocol for a new struct, add the implementation to the "Protocols and Implementations" section. If you create a new schema, add it to the "Custom Structs" section.
 
-*Certified accurate by caleb-bb on 2026-06-19*
+*Certified accurate by Claude on 2026-06-19*
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ mix coveralls.json                         # Must not reduce coverage below thre
 
 `mix quality.fast` (compile + credo) is the minimum local check. `mix quality` adds dialyzer. Tests run with `MIX_ENV=test`; the test alias runs `ecto.create --quiet` and `ecto.migrate --quiet` first.
 
-Dialyzer is not yet a hard push gate (the config line is commented out). Dialyzer is, however, a hard *merge* gate.
+Dialyzer is not a push gate. In CI it runs only on pull requests — the `dialyzer` job in `.github/workflows/quality.yml` is guarded by `if: github.event_name == 'pull_request'` — which makes it a hard *merge* gate rather than a push gate.
 
 ### Pre-push command
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Read these files in full before making any changes:
 
 - `README.md` — the architecture reference. Understand the domain model and module boundaries before touching code.
 - `priv/reference/naming-conventions.md` — at the start of any task involving naming (modules, functions, variables, atoms).
-- `priv/reference/enum-cheat.md` — before writing any collection transformation. If you're about to write explicit recursion over a list, check this first.
+- `priv/reference/enum-cheat.cheatmd` — before writing any collection transformation. If you're about to write explicit recursion over a list, check this first.
 
 ### Load by trigger
 
@@ -36,7 +36,7 @@ These reference files in `priv/reference/` should be loaded when the task matche
 |---|---|
 | Refactor function bodies, change pattern matching, modify string/list/map logic, add parameters, change arity, modify exception handling, introduce boolean/flag params | `code-anti-patterns.md` + `patterns-and-guards.md` |
 | Create/rename/move modules, restructure directories, define new public APIs or behaviours, add/change structs or schemas, introduce dependencies, change module call graphs, add config | `design-anti-patterns.md` |
-| Write/modify macros, `use` declarations, `quote`/`unquote`, DSLs, compile-time code generation | `macro-anti-patterns.md` + `macros.md` + `quote-and-unquote.md` |
+| Write/modify macros, `use` declarations, `quote`/`unquote`, DSLs, compile-time code generation | `macro-anti-patterns.md` + `macros.md` |
 | Create/modify/supervise GenServers/Agents/Tasks, modify supervision tree, use spawn/Task.async, work with Registry/PubSub/message passing | `process-anti-patterns.md` + `genservers.md` + `supervisor-and-application.md` (add `dynamic-supervisor.md` if dynamic spawning) |
 | Write/modify `@type`, `@spec`, address type warnings, design data types | `gradual-set-theoretic-types.md` + `typespecs.md` |
 | Write/modify public API for external consumption, design behaviours for third-party use | `library-guidelines.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,4 @@ The dev environment runs three containers via `docker-compose.yml`: `cake_app`, 
 
 If your task touches any of these, flag it to the user rather than silently resolving or ignoring it.
 
-- **`Conversation.start_link/6` positional args**: Should eventually accept a struct.
 - **Post-demo formats**: Word, Excel, CSV, JPG pipelines are explicitly deferred.
-- **`Responses` hardcoded to `Chunk`**: Generalizing post-processing beyond `Cake.Books.Chunk` to work with any GDS's atomic unit is a known TODO.
-- **`search_fields/0` behaviour extraction**: TODO to extract into a behaviour on the pipeline generics so each GDS declares its searchable fields.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Cake — RAG Framework for Enterprise Document Q&A"
 tags: [cake, rag, elixir, phoenix, opensearch, architecture, domain-model]
-date: 2026-04-23
+date: 2026-06-19
 domain: architecture, reference
 source: project-maintainer
 ---

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Protocols in Cake define value-level contracts. The question they answer is "wha
 
 ### ParsedBook Fields
 
-`title`, `authors` (string array), `source_format`, `file_hash` (deduplication), `file_size`, `word_count`, `total_pages`, `parsed_at`, `embedding_status` (enum: pending/processing/completed/failed), `metadata` (map), `table_of_contents` (map), `language` (ISO code), `isbn`, `publisher`, `publication_date`. Has many `Chunk` records.
+`title`, `source_file_path` (required; the file location used for downloads and the `Citable` `source_ref`), `authors` (string array), `source_format`, `file_hash` (deduplication), `file_size`, `word_count`, `total_pages`, `parsed_at`, `embedding_status` (enum: pending/processing/completed/failed), `metadata` (map), `table_of_contents` (map), `language` (ISO code), `isbn`, `publisher`, `publication_date`. Has many `Chunk` records.
 
 ### Chunk Fields
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ OpenSearch queries support three modes via `search_type`: `:keyword` (BM25 multi
 
 ## Roadmap: Planned and Deferred
 
-**Post-demo planned:** conversation layer decomposition (extract `Prompt` and `Generation` fully; collapse `Responses` to post-processing only), test coverage expansion, generalize `Responses` beyond `Chunk`, `search_fields/0` behaviour extraction, `Conversation.start_link` struct migration, Word/Excel/CSV/JPG pipelines.
+**Post-demo planned:** conversation layer decomposition (extract `Prompt` and `Generation` fully; collapse `Responses` to post-processing only), test coverage expansion, Word/Excel/CSV/JPG pipelines.
 
 **Longer-term:** query decomposition (`Prompt`), autorating (`Search` or dedicated module), cross-encoder reranking (`Search`), HyDE-style query expansion (`Prompt` + `Retrieval`), multi-index search and result merging (`Retrieval`).
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ Step names follow `"pipeline.step"` convention (e.g., `"books.parse"`, `"docs.em
 
 ## Search Design
 
-OpenSearch queries support three modes via `search_type`: `:keyword` (BM25 multi_match), `:vector` (k-NN with cosine similarity, HNSW/FAISS, k=30, ef_search=256), and `:hybrid` (vector in `must`, keyword in `should` with configurable boost). Hybrid is the default because pure vector search struggles with exact identifiers and rare terms, while pure keyword search misses semantic similarity.
+OpenSearch queries support three modes via `search_type`: `:keyword` (BM25 multi_match), `:vector` (k-NN with cosine similarity over an HNSW/FAISS index; the knn clause sets `k=30` at query time), and `:hybrid` (vector in `must`, keyword in `should` with configurable boost). Hybrid is the default because pure vector search struggles with exact identifiers and rare terms, while pure keyword search misses semantic similarity.
+
+Note: `ef_search` is exposed as a default (`default_ef_search/0`, currently 256) but is **not** currently applied to the query — `build_query/_` sets only `k` on the knn clause. Tuning recall via `ef_search` would require configuring it as an index/engine-level k-NN parameter rather than passing it per query.
 
 `search_chunks_with_context/5` returns a list of `Cake.Search.Result.t()` structs. Direct hits carry `hit_source: :search` and the backend `_score`; expanded neighbors carry `hit_source: :expansion` and `backend_score: nil`. The Result struct is the single carrier of retrieval metadata through the rest of the pipeline (scoring, prompt assembly, response post-processing) — everything above the Search.Result boundary speaks CAKE; everything below speaks vendor. CAKE-computed scores (`cosine_score`, `relevance_score`) are populated by `Search.score_results/2` and `Search.normalize_and_combine/1`; `prompt_index` is populated by `Prompt.prepare_context/2`. Each Result also carries a `Search.Provenance` describing the search conditions (type, query text) under which it was discovered.
 

--- a/README.md
+++ b/README.md
@@ -313,34 +313,51 @@ OpenSearch queries support three modes via `search_type`: `:keyword` (BM25 multi
 
 ```
 lib/
+  schema.ex                  # Base Ecto schema macro — `use Cake.Schema` (lib/schema.ex, not under cake/)
   cake/
+    application.ex           # OTP application + supervision tree
     accounts/                # Phoenix auth (User, UserToken, UserNotifier)
-    books/                   # Book ingestion subsystem
+    books/                   # Book ingestion subsystem (ParsedBook + Chunk GDS)
       chunk.ex               #   Chunk schema (retrieval unit)
       parsed_book.ex         #   ParsedBook schema (GDS identity)
       pipeline.ex            #   Books.Pipeline behaviour + orchestrator
       pdf/pipeline.ex        #   PDF implementation (Rustler NIF)
-    documents/               # Documentation ingestion subsystem
+      persistence.ex         #   Write-path: persist book + chunks, hash dedup
+      retrieval.ex           #   Read-path: GDS hit hydration + neighbor expansion
+      page_content.ex        #   NIF-decoded struct: one page's text
+      pdf_extraction.ex      #   NIF-decoded struct: full PDF extraction result
+      skipped_page.ex        #   NIF-decoded struct: a page that failed extraction
+    documents/               # Documentation ingestion subsystem (ParsedDocument GDS)
       cluster.ex             #   OpenSearch Snap.Cluster (connection + index lifecycle)
       parsed_document.ex     #   ParsedDocument schema (GDS identity + retrieval unit)
       parsed_documents.ex    #   ParsedDocuments context (CRUD)
       pipeline.ex            #   Documents.Pipeline behaviour + orchestrator
-      hexdocs/               #   Hexdocs implementation
+      hexdocs.ex             #   Hexdocs context (CRUD over raw hexdocs)
+      hexdocs/
         hexdoc.ex            #     Raw hexdoc schema
         pipeline.ex          #     Hexdocs.Pipeline implementation
+    jobs/
+      document_ingestion_job.ex  # Oban job that runs Documents.Pipeline.ingest
     failed_ingests/          # FailedIngest schema + context
+    parse_books.ex           # Rustler NIF wrapper (PDF extraction)
     search.ex                # Cake.Search behaviour contract + pure scoring utilities
     search/
       query.ex               #   Composable query builder (new/2, knn/4, match/4, to_query_map/1)
       open_search.ex         #   Cake.Search.OpenSearch — real implementation
+      result.ex              #   Search.Result struct (retrieval-metadata carrier)
+      provenance.ex          #   Search.Provenance struct (search conditions)
     candidates.ex            # Pure-function candidate grouping and chunk-ID extraction
     conversation.ex          # Conversation GenServer (orchestrator)
+    conversation/
+      state.ex               #   Conversation state struct
+      events.ex              #   PubSub topic + event helpers
     gds.ex                   # Cake.GDS behaviour
     promptable.ex            # Cake.Promptable protocol
     citable.ex               # Cake.Citable protocol
     citations.ex             # Pure-function citation parser
-    embeddings.ex            # OpenAI embeddings client + Behaviour
-    generation.ex            # Cake.Generation behaviour (contract only)
+    embeddings.ex            # OpenAI embeddings client (Cake.Embeddings.Behaviour impl)
+    embeddings/behaviour.ex  #   Cake.Embeddings.Behaviour contract
+    generation.ex            # Cake.Generation behaviour
     generation/
       open_ai.ex             #   Cake.Generation.OpenAI — real implementation
       anthropic.ex           #   Cake.Generation.Anthropic — placeholder stub
@@ -350,14 +367,19 @@ lib/
     responses/
       behaviour.ex           #   Cake.Responses.Behaviour (contract)
       result.ex              #   Cake.Responses.Result struct
-    schema.ex                # Base schema (use Cake.Schema)
   cake_web/
+    controllers/
+      books_controller.ex    #   Authenticated book-file download (root-confined)
     live/
       chat_live.ex           # LiveView chat UI
       chat_live/
         question_form.ex     #   Embedded schema for question + mode validation
-        selection_form.ex    #   Embedded schema for document selection validation
-    user_auth.ex             # Auth plugs
+        selection_form.ex    #   Embedded schema for document-selection validation
+      search_live.ex         # LiveView search UI
+    router.ex                # Routes + auth pipelines
+    user_auth.ex             # Auth plugs + LiveView on_mount hooks
+  mix/tasks/
+    hooks.install.ex         # `mix hooks.install` — installs the pre-push git hook
 
 test/
   support/

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Every custom struct in Cake, its module, its purpose, and whether it defines a `
 | `Search.Result` | `Cake.Search.Result` | Normalized search result. Carries retrieval unit, backend score, CAKE-computed scores (cosine, relevance), hit provenance (search vs. expansion), search conditions, and prompt index. Single carrier of all retrieval metadata through the pipeline. |
 | `Search.Provenance` | `Cake.Search.Provenance` | Search conditions (type, query text, decomposition flag, embedding model) attached to each `Search.Result`. |
 | `Responses.Result` | `Cake.Responses.Result` | Output struct from post-generation processing. Contains the formatted response, citations, and chunk map. |
+| `Conversation.State` | `Cake.Conversation.State` | Internal state for the `Conversation` GenServer: id, collaborator modules, message history, retrieved results, chunk map, citations, and the turn FSM state. |
+| `Books.PageContent` | `Cake.Books.PageContent` | Elixir-side struct the Rust PDF NIF decodes into (via NifStruct): one page's extracted text and page number. |
+| `Books.PdfExtraction` | `Cake.Books.PdfExtraction` | Elixir-side struct the Rust PDF NIF decodes into: the full extraction result (pages, skipped pages, title). |
+| `Books.SkippedPage` | `Cake.Books.SkippedPage` | Elixir-side struct the Rust PDF NIF decodes into: a page that could not be extracted, with its page number. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Conversation → Generation
 Conversation → Responses
 ```
 
-**`Cake.Conversation`** is a GenServer managing single-conversation state: message history, retrieved chunks, chunk map, citations, accumulated errors. First `ask/3` performs the full retrieve-and-generate loop; subsequent `ask/2` calls skip retrieval and reuse cached search results.
+**`Cake.Conversation`** is a GenServer managing single-conversation state: message history, retrieved chunks, chunk map, citations, accumulated errors. A turn starts one of two ways: `autoask/2` runs the full retrieve-and-generate loop automatically, while `manualask/2` retrieves and returns candidate documents (`[Search.Result.t()]`) for the user to pick from — `select_docs/2` then supplies the chosen document ids and generation proceeds. Follow-up turns reuse cached search results rather than re-retrieving.
 
 **`Cake.Prompt`** owns prompt engineering. Builds the messages list for the LLM (system prompt, conversation history, retrieved context as a numbered block, user question). Handles query decomposition by calling `Generation` when needed. Filters chunks by relevance floor and chunk ceiling, assigns dense 1..N indices.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There is deliberately no `Cake.Ingestion` behaviour unifying the two pipeline be
 
 ### Layer 2: Search and Retrieval
 
-**`Cake.Search`** is a behaviour (contract only) defining the search interface. `Cake.Search.OpenSearch` is the real implementation.
+**`Cake.Search`** defines the search behaviour contract and also owns the pure scoring utilities (`cosine_similarity/2`, `score_results/2`, `normalize_and_combine/1`, `sort_by_relevance/1`) that rank retrieved results. `Cake.Search.OpenSearch` is the real backend implementation.
 
 **`Cake.Search.Query`** is a struct-based composable OpenSearch query builder. Struct fields: `index` (enforced), `size` (default 10), `must`, `should`, `filter` (all default `[]`), `min_score` (default nil). Builder functions: `new/2`, `knn/4`, `match/4`, `filter_term/3`, `min_score/2`, `size/2`. Conversion: `to_query_map/1`.
 
@@ -325,7 +325,7 @@ lib/
         hexdoc.ex            #     Raw hexdoc schema
         pipeline.ex          #     Hexdocs.Pipeline implementation
     failed_ingests/          # FailedIngest schema + context
-    search.ex                # Cake.Search behaviour (contract only)
+    search.ex                # Cake.Search behaviour contract + pure scoring utilities
     search/
       query.ex               #   Composable query builder (new/2, knn/4, match/4, to_query_map/1)
       open_search.ex         #   Cake.Search.OpenSearch — real implementation

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ lib/
     failed_ingests/          # FailedIngest schema + context
     search.ex                # Cake.Search behaviour (contract only)
     search/
-      query.ex               #   Query struct: build/3, to_opensearch/1
+      query.ex               #   Composable query builder (new/2, knn/4, match/4, to_query_map/1)
       open_search.ex         #   Cake.Search.OpenSearch — real implementation
     candidates.ex            # Pure-function candidate grouping and chunk-ID extraction
     conversation.ex          # Conversation GenServer (orchestrator)

--- a/lib/cake/books/pipeline.ex
+++ b/lib/cake/books/pipeline.ex
@@ -11,7 +11,8 @@ defmodule Cake.Books.Pipeline do
   paths = Enum.map("HASHTAG{assets_path}/HASHTAG{&1}")
   Cake.Books.Pipeline.ingest(:openai, Cake.Books.Pdf.Pipeline,  "text-embedding-ada-002", paths)
   Cake.Books.Pipeline.ingest_with_sweep(:openai, Cake.Books.Pdf.Pipeline,  "text-embedding-ada-002", paths)
-  {:ok, pid} = Cake.Conversation.start_link(Cake.Documents.Cluster,"text-embedding-ada-002", "chunks_of_books", "gpt-5", :openai, :keyword)
+  opts = Map.put(Map.new(Application.fetch_env!(:cake, Cake.Conversation)), :id, Ecto.UUID.generate())
+  {:ok, pid} = Cake.Conversation.start_link(opts)
   Cake.Conversation.autoask(pid, "How do I install the P/N:  98-0110 Rev. A dealkalizer? What's the max flow rate on the SCALA2?")
   GenServer.cast(pid, :inspect)
   """

--- a/lib/cake/pipelines.ex
+++ b/lib/cake/pipelines.ex
@@ -259,16 +259,6 @@ defmodule Cake.Pipelines do
     summarize_ingest(message, indexed, failed)
   end
 
-  @spec detuple(Enumerable.t()) :: Enumerable.t()
-  def detuple(stream_enumerable) do
-    stream_enumerable
-    |> Stream.filter(fn
-      {:ok, _} -> true
-      _ -> false
-    end)
-    |> Stream.map(fn {:ok, value} -> value end)
-  end
-
   @spec build_context(atom(), atom(), any(), list()) :: context()
   def build_context(behaviour_module, source_pipeline, version, opts \\ [])
 

--- a/priv/hooks/pre-push
+++ b/priv/hooks/pre-push
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "==> Running 'mix compile --force --warnings-as-errors'"
-echo "==> Compiling..."
+# Mirrors the documented pre-push chain in CLAUDE.md and the on-push CI gate:
+#   mix compile --warnings-as-errors && mix test --exclude integration \
+#     && mix credo --strict && mix format --check-formatted
+# Integration tests (OpenSearch / external HTTP / Rustler NIF) run separately
+# as a merge gate, so they are excluded here.
+
+echo "==> Running 'mix compile --force --warnings-as-errors' (pre-push gate 1)..."
 
 if ! mix compile --force --warnings-as-errors; then
     echo ""
-    echo "!! Push rejected: Your code doesn't even COMPILE without warings, bro."
+    echo "!! Push rejected: Your code doesn't even COMPILE without warnings, bro."
     exit 1
 fi
 
-echo "==> Code compiles with no errors."
-echo "==> Running Credo (pre-push gate 2)..."
+echo "==> Code compiles with no warnings. Running tests (pre-push gate 2)..."
+
+if ! mix test --exclude integration; then
+  echo ""
+  echo "!! Push rejected: Tests are failing."
+  echo "!! Run 'mix test --exclude integration' to see details, fix them, then push again."
+  exit 1
+fi
+
+echo "==> Tests passed. Running Credo (pre-push gate 3)..."
 
 if ! mix credo --strict; then
   echo ""
@@ -20,13 +33,13 @@ if ! mix credo --strict; then
   exit 1
 fi
 
-echo "==> Credo passed. Running tests (pre-push gate 3)..."
+echo "==> Credo passed. Checking formatting (pre-push gate 4)..."
 
-if ! mix test; then
+if ! mix format --check-formatted; then
   echo ""
-  echo "!! Push rejected: Tests are failing."
-  echo "!! Run 'mix test' to see details, fix them, then push again."
+  echo "!! Push rejected: Code is not formatted."
+  echo "!! Run 'mix format', then push again."
   exit 1
 fi
 
-echo "==> Tests passed. Pushing."
+echo "==> All gates passed. Pushing."


### PR DESCRIPTION
Closes #175 — reconciles README.md + CLAUDE.md (and a couple of code/infra artifacts) with the actual code. One commit per checkbox, 14 total.

## Contradictions fixed
- **Conversation API** (`9ed9e56`) — README claimed `ask/3`/`ask/2`; replaced with the real `autoask/2` / `manualask/2` / `select_docs/2` and the auto-vs-manual distinction.
- **query.ex names in tree** (`570f57c`) — `build/3, to_opensearch/1` → the real builder API.
- **`Cake.Search` "contract only"** (`1e43d5d`) — reworded to "behaviour contract + pure scoring utilities" (it owns `cosine_similarity/2`, `score_results/2`, etc.).
- **Pre-push hook** (`719f5d5`) — the installed `priv/hooks/pre-push` ran full `mix test` (incl. `:integration`) and no format check. **Decision: updated the hook to match the documented chain** (`compile → test --exclude integration → credo --strict → format`), since CLAUDE.md explicitly excludes integration from the on-push gate and running it on every push needs OpenSearch/HTTP/NIF. Also fixed the "warings" typo.
- **Reference filenames** (`4397466`) — `enum-cheat.md` → `.cheatmd`; removed the non-existent `quote-and-unquote.md`.
- **Dialyzer gate wording** (`d552a5d`) — there's no commented config line; reworded to the real `if: github.event_name == 'pull_request'` guard in `quality.yml`.

## Stale defects / roadmap pruned
- **Known Defects + roadmap** (`d8ca346`) — removed three resolved items (`start_link/6`, `Responses` hardcoded to `Chunk`, `search_fields/0` extraction) from both docs; kept the accurate Word/Excel/CSV/JPG item.
- **Books.Pipeline moduledoc** (`d506449`) — the stale 6-arg `start_link` example (origin of the myth) → current map-based `start_link/1`.

## Enumeration omissions
- **Custom Structs** (`58418c3`) — added `Conversation.State`, `Books.PageContent`, `Books.PdfExtraction`, `Books.SkippedPage`.
- **ParsedBook fields** (`2746423`) — added `source_file_path`.
- **Directory tree** (`8b700d3`) — fixed `schema.ex` location (`lib/schema.ex`) and added ~20 missing modules (notably `Books.Retrieval`).

## Minor / cleanup
- **ef_search** (`ec687fc`) — **Decision: documented** that `ef_search` is exposed but not wired into the knn query (only `k` binds), rather than changing search behavior in a docs issue.
- **Dead code** (`038b490`) — removed `Pipelines.detuple/1` (zero callers after the honest-gates work).

## Close-out
- **Re-certify** (`a89fc80`) — refreshed the CLAUDE.md "Certified accurate" stamps + `last_verified` to 2026-06-19 and bumped the README frontmatter date, **per your instruction in the issue** (the stamps name caleb-bb as certifier; flagging since they imply human certification).

## Verification (full pre-push gate, all green)
- `mix compile --warnings-as-errors` — clean
- `mix test --exclude integration` — 30 properties, 445 tests, 0 failures
- `mix credo` (strict) — 0 issues
- `mix format --check-formatted` — clean
- `bash -n priv/hooks/pre-push` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B97zWC6hpyKwR7A3xf9mUT)_