### PR TITLE
Hexdoc dupe-detection primitive (#57)

### DIFF
--- a/lib/cake/documents/hexdocs.ex
+++ b/lib/cake/documents/hexdocs.ex
@@ -19,6 +19,21 @@ defmodule Cake.Documents.Hexdocs do
   end
 
   @doc """
+  Returns whether a hexdoc already exists for the given `module` and `version`.
+
+  The `(module, version)` pair is the natural dedup key for a raw hexdoc row.
+  Backed by `Repo.exists?/1`, so it is tolerant of pre-existing duplicates
+  (there is no unique constraint on the pair) and never raises on a match.
+  """
+  @spec hexdoc_exists?(String.t(), String.t()) :: boolean()
+  def hexdoc_exists?(module, version) do
+    Hexdoc.base_query()
+    |> Hexdoc.by_module(module)
+    |> Hexdoc.by_version(version)
+    |> Repo.exists?()
+  end
+
+  @doc """
   Returns the list of hexdocs.
 
   ## Examples

--- a/lib/cake/documents/hexdocs/hexdoc.ex
+++ b/lib/cake/documents/hexdocs/hexdoc.ex
@@ -58,6 +58,12 @@ defmodule Cake.Documents.Hexdocs.Hexdoc do
       where: h.version == ^version
   end
 
+  @spec by_module(Ecto.Query.t(), String.t()) :: Ecto.Query.t()
+  def by_module(query, module) do
+    from h in query,
+      where: h.module == ^module
+  end
+
   @spec to_parsed_docs({:ok, %__MODULE__{}} | %__MODULE__{}) :: [map()]
   def to_parsed_docs({:ok, hexdoc}), do: to_parsed_docs(hexdoc)
 

--- a/test/cake/documents/hexdocs/hexdoc_property_test.exs
+++ b/test/cake/documents/hexdocs/hexdoc_property_test.exs
@@ -16,8 +16,10 @@ defmodule Cake.Documents.Hexdocs.HexdocPropertyTest do
 
   describe "hexdoc_exists?/2" do
     property "is true for the (module, version) of any persisted hexdoc" do
-      check all module <- string(:alphanumeric, min_length: 1),
-                version <- string(:alphanumeric, min_length: 1) do
+      check all(
+              module <- string(:alphanumeric, min_length: 1),
+              version <- string(:alphanumeric, min_length: 1)
+            ) do
         hexdoc_fixture(%{module: module, version: version})
         assert Hexdocs.hexdoc_exists?(module, version)
       end

--- a/test/cake/documents/hexdocs/hexdoc_property_test.exs
+++ b/test/cake/documents/hexdocs/hexdoc_property_test.exs
@@ -1,0 +1,26 @@
+defmodule Cake.Documents.Hexdocs.HexdocPropertyTest do
+  @moduledoc """
+  Property tests for the dupe-detection primitive on the Hexdocs context.
+
+  Pins the invariant that `hexdoc_exists?/2` recognizes the (module, version)
+  natural key of any persisted hexdoc. Example tests live in `hexdocs_test.exs`
+  and `hexdoc_test.exs`.
+  """
+
+  use Cake.DataCase, async: true
+  use ExUnitProperties
+
+  import Cake.HexdocsFixtures
+
+  alias Cake.Documents.Hexdocs
+
+  describe "hexdoc_exists?/2" do
+    property "is true for the (module, version) of any persisted hexdoc" do
+      check all module <- string(:alphanumeric, min_length: 1),
+                version <- string(:alphanumeric, min_length: 1) do
+        hexdoc_fixture(%{module: module, version: version})
+        assert Hexdocs.hexdoc_exists?(module, version)
+      end
+    end
+  end
+end

--- a/test/cake/documents/hexdocs/hexdoc_test.exs
+++ b/test/cake/documents/hexdocs/hexdoc_test.exs
@@ -63,6 +63,34 @@ defmodule Cake.Documents.Hexdocs.HexdocTest do
     end
   end
 
+  describe "by_module/2" do
+    test "filters hexdocs by module" do
+      hexdoc_fixture(%{version: "1.18.3", module: "Enum"})
+      hexdoc_fixture(%{version: "1.18.3", module: "Map"})
+
+      results = Hexdoc.base_query() |> Hexdoc.by_module("Enum") |> Repo.all()
+
+      assert length(results) == 1
+      assert hd(results).module == "Enum"
+    end
+
+    test "composes with by_version/2 to select on the (module, version) natural key" do
+      hexdoc_fixture(%{version: "1.18.3", module: "Enum"})
+      hexdoc_fixture(%{version: "1.17.0", module: "Enum"})
+      hexdoc_fixture(%{version: "1.18.3", module: "Map"})
+
+      results =
+        Hexdoc.base_query()
+        |> Hexdoc.by_module("Enum")
+        |> Hexdoc.by_version("1.18.3")
+        |> Repo.all()
+
+      assert length(results) == 1
+      assert hd(results).module == "Enum"
+      assert hd(results).version == "1.18.3"
+    end
+  end
+
   describe "to_parsed_docs/1" do
     test "extracts function docs and code from a simple module" do
       content = """

--- a/test/cake/hexdocs_test.exs
+++ b/test/cake/hexdocs_test.exs
@@ -77,4 +77,33 @@ defmodule Cake.HexdocsTest do
       assert %Ecto.Changeset{} = Hexdocs.change_hexdoc(hexdoc)
     end
   end
+
+  describe "hexdoc_exists?/2" do
+    import Cake.HexdocsFixtures
+
+    test "returns true when a hexdoc with that module and version exists" do
+      hexdoc_fixture(%{module: "Enum", version: "1.18.3"})
+      assert Hexdocs.hexdoc_exists?("Enum", "1.18.3")
+    end
+
+    test "returns false when no hexdoc matches" do
+      refute Hexdocs.hexdoc_exists?("Enum", "1.18.3")
+    end
+
+    test "returns false when the module matches but the version differs" do
+      hexdoc_fixture(%{module: "Enum", version: "1.17.0"})
+      refute Hexdocs.hexdoc_exists?("Enum", "1.18.3")
+    end
+
+    test "returns false when the version matches but the module differs" do
+      hexdoc_fixture(%{module: "Map", version: "1.18.3"})
+      refute Hexdocs.hexdoc_exists?("Enum", "1.18.3")
+    end
+
+    test "tolerates pre-existing duplicates of the same key (the point of dupe detection)" do
+      hexdoc_fixture(%{module: "Enum", version: "1.18.3"})
+      hexdoc_fixture(%{module: "Enum", version: "1.18.3"})
+      assert Hexdocs.hexdoc_exists?("Enum", "1.18.3")
+    end
+  end
 end


### PR DESCRIPTION
Closes #57.

Adds the lookup primitive for detecting duplicate hexdocs by their `(module, version)` natural key. This is the schema/context groundwork the dedup logic in #56 will consume; it does not itself change ingestion behavior.

## What changed

- **`Cake.Documents.Hexdocs.Hexdoc.by_module/2`** — a query composer mirroring the existing `by_version/2`, so callers compose `base_query() |> by_module(m) |> by_version(v)`.
- **`Cake.Documents.Hexdocs.hexdoc_exists?/2`** — a boolean predicate over the `(module, version)` key, backed by `Repo.exists?/1`.

## Contract decisions

- **Natural key = `(module, version)`.** A module's source at a given version is one row; re-ingesting that pair is the duplicate case.
- **Predicate, not a fetch.** `hexdoc_exists?/2` returns a boolean and is **duplicate-tolerant**: there is no unique constraint on the pair yet, so a `get_by`-style fetch could raise `Ecto.MultipleResultsError` on pre-existing dupes. `Repo.exists?/1` answers "is this a dupe?" without raising. One test pins exactly this tolerance.

## Test-driven

Written tests-first (see commit history: failing tests → implementation → format fix):

- `hexdoc_test.exs` — `by_module/2` filters by module and composes with `by_version/2` on the full key.
- `hexdocs_test.exs` — `hexdoc_exists?/2`: present ⇒ true; absent ⇒ false; module-only match ⇒ false; version-only match ⇒ false; duplicate-tolerant ⇒ true.
- `hexdoc_property_test.exs` (new) — property: `hexdoc_exists?/2` is true for the `(module, version)` of any persisted hexdoc.

## Verification

Full local gate, all green:

- `mix compile --warnings-as-errors --force` — clean
- `mix test --exclude integration` — 70 properties, 525 tests, 0 failures (5 integration excluded)
- `mix format --check-formatted` — clean
- `mix credo --strict` — no new findings (the 8 pre-existing are TODO tags in `lib/cake/prompt.ex`)

## Follow-up

Unblocks **#56** (`Cake.Documents.Hexdocs.Pipeline` skip-if-exists), which is the intended first consumer of `hexdoc_exists?/2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dvVgcg1coierTugvRqiUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012dvVgcg1coierTugvRqiUJ)_