### PR TITLE
Run dialyzer on push to master to seed PLT cache

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -193,7 +193,6 @@ jobs:
   dialyzer:
     name: Dialyzer
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The dialyzer job was gated by `if: github.event_name == 'pull_request'`, meaning it never ran on master. GitHub Actions cache scoping prevents PR branches from reading caches that only exist on other feature branches, so every new PR rebuilt all three PLT layers from scratch (~2min).

Removing the guard lets push-to-master runs seed the PLT cache that all subsequent PR branches can restore.