### PR TITLE
Stricter compile/test/xref gates (#198)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -171,7 +171,7 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Run tests with coverage (excluding integration)
-        run: mix coveralls.json --exclude integration
+        run: mix coveralls.json --exclude integration --warnings-as-errors
 
   integration:
     name: Integration Tests (merge gate)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,6 +65,16 @@ jobs:
       - name: Format check
         run: mix format --check-formatted
 
+      # Ratchet gate against compile-time coupling creep. Run in the dev env so
+      # it measures only the application graph (excludes the Mox mocks in
+      # test/support, which structurally compile-depend on their behaviours).
+      # Baseline is the current count (3, from Cake.Conversation.State's
+      # defstruct DI defaults); ratchet it down to 0 once that is decoupled — #208.
+      - name: Compile-time coupling ratchet (xref)
+        env:
+          MIX_ENV: dev
+        run: mix xref graph --label compile-connected --fail-above 3
+
   security:
     name: Security & Dependency Audit
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,7 @@ defmodule Cake.MixProject do
       setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test --warnings-as-errors"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": ["tailwind cake", "esbuild cake"],
       "assets.deploy": [

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -28,7 +28,7 @@ defmodule Cake.ConversationTest do
   use ExUnit.Case, async: false
 
   import Mox
-  import Cake.Factory, only: [build: 1, build: 2, chunk_metadata: 1]
+  import Cake.Factory, only: [build: 2, chunk_metadata: 1]
 
   alias Cake.Conversation
   alias Cake.Search.Hit

--- a/test/cake/jobs/document_ingestion_job_test.exs
+++ b/test/cake/jobs/document_ingestion_job_test.exs
@@ -13,8 +13,6 @@ defmodule Cake.Jobs.DocumentIngestionJobTest do
   alias Cake.Jobs.DocumentIngestionJob
   alias Cake.TestPipeline
 
-  require Logger
-
   # Allow mocks to be used in tests
   setup :verify_on_exit!
 

--- a/test/cake/pipelines_test.exs
+++ b/test/cake/pipelines_test.exs
@@ -98,15 +98,17 @@ defmodule Cake.PipelinesTest do
     end
 
     test "raises FunctionClauseError when given a raw version string" do
-      # Guards against regression to the old callback signature.
+      # Guards against regression to the old callback signature. The bad arg is
+      # passed via apply/3 so the deliberate type mismatch stays a runtime
+      # concern instead of a compile-time warning.
       assert_raise FunctionClauseError, fn ->
-        TestPipeline.success_message("1.18.3")
+        apply(TestPipeline, :success_message, ["1.18.3"])
       end
     end
 
     test "raises FunctionClauseError when given a non-Context map" do
       assert_raise FunctionClauseError, fn ->
-        TestPipeline.success_message(%{version: "1.18.3", implementation: "x"})
+        apply(TestPipeline, :success_message, [%{version: "1.18.3", implementation: "x"}])
       end
     end
   end
@@ -124,7 +126,7 @@ defmodule Cake.PipelinesTest do
 
     test "raises FunctionClauseError when given a raw version string" do
       assert_raise FunctionClauseError, fn ->
-        FailingTestPipeline.success_message("1.18.3")
+        apply(FailingTestPipeline, :success_message, ["1.18.3"])
       end
     end
   end


### PR DESCRIPTION
Implements #198 — tightens the test and xref gates. One commit per checklist item.

## Commits

1. **Treat test warnings as errors** — adds `--warnings-as-errors` to the `test` alias and the `coveralls.json` CI step (the standalone compile step already covered `lib/`, but test files weren't). Cleared the 5 pre-existing test-file warnings this surfaced:
   - unused `require Logger` (`document_ingestion_job_test`)
   - unused `import Cake.Factory.build/1` (`conversation_test`)
   - 3 deliberate wrong-type calls to `success_message/1` in `pipelines_test`, now routed through `apply/3` so the intended `FunctionClauseError` stays a **runtime** assertion instead of a compile-time type warning (assertions unchanged).
2. **xref compile-connected ratchet gate** — CI step catching compile-time coupling creep.

## Note on the xref threshold (`--fail-above 3`, not `0`)

The issue text says `--fail-above 0`, but the graph isn't at 0 today, so I used a **ratchet baseline** instead — matching this repo's established ratchet policy (#180) and the issue's stated intent ("catch accidental compile-time coupling creep"):

- The application graph has **3** compile-connected edges, all from `Cake.Conversation.State`'s `defstruct` DI defaults (`embeddings: Cake.Embeddings`, etc.) — `defstruct` defaults evaluate at compile time. Removing them is a struct/architecture change (CLAUDE.md "stop and ask"), so it's tracked separately in **#208**, whose second commit lowers the baseline to `0`.
- The step runs in the **dev** env so it measures only the application graph. In the `test` env, `test/support/mocks.ex` adds 2 more edges that are structural to `Mox.defmock` (the behaviour is needed at compile time) and shouldn't count against the app.

The gate is real: it's green at `3` today and fails at `2`, so any new compile coupling trips it.

## Verification (Elixir 1.20.2 / OTP 27, local Postgres)

| Check | Result |
|---|---|
| `mix test --warnings-as-errors --exclude integration` | **629 passed, 0 warnings, exit 0** |
| `MIX_ENV=dev mix xref graph --label compile-connected --fail-above 3` | exit 0 (green) |
| same at `--fail-above 2` | exit 1 (proves it gates) |
| `mix format --check-formatted` (changed files) | clean |
| workflow YAML | parses |

One caveat: I couldn't run `mix coveralls.json` to completion locally — it hits a pre-existing `:cover` instrumentation crash (`do_compile_beam2`) on this OTP-27 setup that reproduces **without** my flag too, so it's unrelated. The flag just forwards to the test run verified above.

Closes #198. Follow-up: #208 (decouple `State`, ratchet xref to 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_