### PR TITLE
Add `mix precommit` alias (#199)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ mix test                                   # Zero failures, zero warnings.
 mix coveralls.json                         # Must not reduce coverage below minimum (coveralls.json is the SSOT for the threshold).
 ```
 
-`mix quality.fast` (compile + credo + `deps.unlock --check-unused`) is the minimum local check. `mix quality` adds dialyzer. Tests run with `MIX_ENV=test`; the test alias runs `ecto.create --quiet` and `ecto.migrate --quiet` first.
+`mix quality.fast` (compile + credo + `deps.unlock --check-unused`) is the minimum local check; `mix precommit` is the fuller pre-push check (adds format + tests — see Pre-push below). `mix quality` adds dialyzer. Tests run with `MIX_ENV=test`; the test alias runs `ecto.create --quiet` and `ecto.migrate --quiet` first.
 
 Dialyzer is not a push gate. In CI it runs only on PRs — the `dialyzer` job in `.github/workflows/quality.yml` is guarded by `if: github.event_name == 'pull_request'` — making it a hard *merge* gate, not a push gate.
 
@@ -63,7 +63,7 @@ The `security` job in `.github/workflows/quality.yml` runs the dependency-audit 
 ```bash
 mix compile --force --warnings-as-errors && mix test --exclude integration && mix credo --strict && mix format --check-formatted
 ```
-Tests tagged `:integration` (OpenSearch, external HTTP, or the Rustler NIF) are excluded on-push and run separately as a merge gate via `mix test --only integration`.
+`mix precommit` bundles this exact chain into one command (compile → format check → credo → tests, integration excluded) — run it before pushing. Tests tagged `:integration` (OpenSearch, external HTTP, or the Rustler NIF) are excluded on-push and run separately as a merge gate via `mix test --only integration`.
 
 ---
 

--- a/mix.exs
+++ b/mix.exs
@@ -120,6 +120,13 @@ defmodule Cake.MixProject do
         "compile --warnings-as-errors",
         "credo --strict",
         "deps.unlock --check-unused"
+      ],
+      # One command matching the on-push CI gate (see CLAUDE.md "Pre-push").
+      precommit: [
+        "compile --force --warnings-as-errors",
+        "format --check-formatted",
+        "credo --strict",
+        "test --exclude integration"
       ]
       # `mix hooks.install` is the Mix.Tasks.Hooks.Install task
       # (lib/mix/tasks/hooks.install.ex), which installs every hook in priv/hooks/.


### PR DESCRIPTION
Implements #199 — a single `mix precommit` command bundling the on-push CI gate. One commit per checklist item.

## Commits

1. **Add the `precommit` alias** in `mix.exs`, matching the documented pre-push chain:
   ```
   compile --force --warnings-as-errors → format --check-formatted → credo --strict → test --exclude integration
   ```
2. **Document it** in CLAUDE.md (Quality Gates + Pre-push sections).

## Note on the README

The checklist said "document in CLAUDE.md **and README**", but `README.md` is the architecture reference and has no dev-commands/tooling section — per the repo's own doc split ("README describes what things are and why; CLAUDE.md tells you what you must do"), gate commands live in CLAUDE.md. I documented it there rather than inventing a section in the README. Happy to add a README note if you'd prefer.

## Verification (Elixir 1.20.2 / OTP 27, local Postgres)

Ran the alias end-to-end:

| | Result |
|---|---|
| `mix precommit` (full chain) | **exit 0** — compile + format + credo + 629 tests all pass |
| `mix format --check-formatted mix.exs` | clean |

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_