### PR TITLE
Strengthen weak test assertions and enable Jump WeakAssertion check (#217)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -140,15 +140,12 @@
           #     (`@enforce_keys`, defaults) and the `apply/3` FunctionClauseError
           #     tests in pipelines_test (the check can't see `apply/3` as calling
           #     application code) — enabling them would force artificial rewrites.
-          #   - WeakAssertion: flags ~26 `assert <truthy-call>` sites across the
-          #     suite. Strengthening each to a specific assertion is a worthwhile
-          #     but sizable, judgement-heavy test refactor — deferred to its own
-          #     pass rather than bundled here.
           #   - ConditionalAssertion: flags legitimate `or`/`||` assertions — a
           #     property test where a label validly matches either of two
           #     formats, prompt-wording flexibility, and result-shape checks for
           #     non-deterministic jobs; pinning a single value isn't possible.
           {Jump.CredoChecks.SafeBinaryToTerm, []},
+          {Jump.CredoChecks.WeakAssertion, []},
           {Jump.CredoChecks.UnusedLiveViewAssign, []},
           {Jump.CredoChecks.LiveViewFormCanBeRehydrated, []},
           {Jump.CredoChecks.AssertReceiveTimeout, []},

--- a/test/cake/accounts_test.exs
+++ b/test/cake/accounts_test.exs
@@ -89,7 +89,7 @@ defmodule Cake.AccountsTest do
       email = unique_user_email()
       {:ok, user} = Accounts.register_user(valid_user_attributes(email: email))
       assert user.email == email
-      assert is_binary(user.hashed_password)
+      assert user.hashed_password =~ ~r/^\$2[aby]\$/
       assert is_nil(user.confirmed_at)
       assert is_nil(user.password)
     end

--- a/test/cake/books/chunk_promptable_test.exs
+++ b/test/cake/books/chunk_promptable_test.exs
@@ -69,7 +69,7 @@ defmodule Cake.Books.ChunkPromptableTest do
     end
 
     test "returns a String" do
-      assert is_binary(Promptable.prompt_context(chunk(%{})))
+      assert Promptable.prompt_context(chunk(%{})) =~ "Book: RO-400 Manual | Page: 42"
     end
   end
 end

--- a/test/cake/citations_test.exs
+++ b/test/cake/citations_test.exs
@@ -50,8 +50,8 @@ defmodule Cake.CitationsTest do
   describe "extract/2" do
     test "returns a two-tuple of {citations, hallucinated}" do
       assert {citations, hallucinated} = Citations.extract("Use [1]", @chunk_map)
-      assert is_list(citations)
-      assert is_list(hallucinated)
+      assert length(citations) == 1
+      assert hallucinated == []
     end
 
     test "valid citations preserve first-appearance order" do

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -296,21 +296,21 @@ defmodule Cake.ConversationTest do
       assert response == "answer [1] with [2] and [3]"
       assert length(citations) == 3
 
-      Enum.each(citations, fn citation ->
-        assert Map.has_key?(citation, :old_index)
-        assert Map.has_key?(citation, :new_index)
-        assert Map.has_key?(citation, :id)
-        assert Map.has_key?(citation, :label)
-        assert Map.has_key?(citation, :preview)
-        assert Map.has_key?(citation, :source_ref)
-        assert Map.has_key?(citation, :extras)
+      for {citation, i} <- Enum.with_index(citations, 1) do
+        assert citation.old_index == i
+        assert citation.new_index == i
+        assert citation.id == "id-#{i}"
+        assert citation.label == "Book #{i}, p. #{i}"
+        assert citation.preview == "preview #{i}"
+        assert citation.source_ref == "book:#{i}#chunk:#{i}"
 
-        assert is_integer(citation.old_index)
-        assert is_integer(citation.new_index)
-        assert is_binary(citation.label)
-        assert is_binary(citation.preview)
-        assert is_map(citation.extras)
-      end)
+        assert citation.extras == %{
+                 book_title: "Book #{i}",
+                 page_number: i,
+                 section_title: "Section #{i}",
+                 chunk_index: i
+               }
+      end
     end
   end
 

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -294,11 +294,9 @@ defmodule Cake.ConversationTest do
       assert_receive {:response_ready, %{response: response, citations: citations}}
 
       assert is_binary(response)
-      assert is_list(citations)
       assert length(citations) == 3
 
       Enum.each(citations, fn citation ->
-        assert is_map(citation)
         assert Map.has_key?(citation, :old_index)
         assert Map.has_key?(citation, :new_index)
         assert Map.has_key?(citation, :id)

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -293,7 +293,7 @@ defmodule Cake.ConversationTest do
 
       assert_receive {:response_ready, %{response: response, citations: citations}}
 
-      assert is_binary(response)
+      assert response == "answer [1] with [2] and [3]"
       assert length(citations) == 3
 
       Enum.each(citations, fn citation ->
@@ -769,7 +769,7 @@ defmodule Cake.ConversationTest do
 
       assert_receive {:response_ready, %{response: response, citations: citations}}
 
-      assert is_binary(response)
+      assert response == "answer with no citation markers"
       assert citations == []
     end
   end
@@ -1251,7 +1251,7 @@ defmodule Cake.ConversationTest do
       # State is now awaiting_selection
       pre_select = :sys.get_state(pid)
       assert pre_select.state == :awaiting_selection
-      assert pre_select.pending != nil
+      assert %{question: "manual question", candidates: _} = pre_select.pending
 
       # Step 2: select with chunk IDs completes the turn
       doc_ids =

--- a/test/cake/documents/hexdocs/hexdoc_test.exs
+++ b/test/cake/documents/hexdocs/hexdoc_test.exs
@@ -115,7 +115,6 @@ defmodule Cake.Documents.Hexdocs.HexdocTest do
       assert length(docs) == 2
 
       add_doc = Enum.find(docs, &(&1.text =~ "Adds two numbers."))
-      assert add_doc
       assert add_doc.text =~ "def add(a, b)"
       assert add_doc.url == "https://hexdocs.pm/elixir/Example.html"
       assert add_doc.package == "Example"

--- a/test/cake/documents/parsed_document_promptable_test.exs
+++ b/test/cake/documents/parsed_document_promptable_test.exs
@@ -56,7 +56,10 @@ defmodule Cake.Documents.ParsedDocumentPromptableTest do
         text: "some text"
       }
 
-      assert is_binary(Promptable.prompt_context(doc))
+      assert Promptable.prompt_context(doc) ==
+               "Package: Enum | Function: map/2\n" <>
+                 "URL: https://hexdocs.pm/elixir/Enum.html#map/2\n\n" <>
+                 "some text"
     end
   end
 end

--- a/test/cake/embeddings_test.exs
+++ b/test/cake/embeddings_test.exs
@@ -59,7 +59,6 @@ defmodule Cake.EmbeddingsTest do
       result = Embeddings.embed(:openai, %{input: "hello"}, "text-embedding-ada-002")
 
       assert {:error, message} = result
-      assert is_binary(message)
       assert message =~ "Cake.Embeddings"
       assert message =~ "Application layer error"
     end

--- a/test/cake/embeddings_test.exs
+++ b/test/cake/embeddings_test.exs
@@ -102,7 +102,7 @@ defmodule Cake.EmbeddingsTest do
 
       assert result.struct == doc
       assert result.attrs == %{embedding: [0.1, 0.2, 0.3]}
-      assert is_map(result.usage)
+      assert result.usage == %{"total_tokens" => 5}
     end
 
     test "struct is nil when the input carries no struct" do

--- a/test/cake/generation/open_ai_test.exs
+++ b/test/cake/generation/open_ai_test.exs
@@ -150,7 +150,7 @@ defmodule Cake.Generation.OpenAITest do
       end)
 
       assert {:error, {:auth, body}} = OpenAI.complete(@default_messages, @default_model)
-      assert is_binary(body)
+      assert body =~ "invalid api key"
     end
 
     test "429 with Retry-After header returns {:rate_limited, seconds}" do

--- a/test/cake/jobs/document_ingestion_job_test.exs
+++ b/test/cake/jobs/document_ingestion_job_test.exs
@@ -298,7 +298,6 @@ defmodule Cake.Jobs.DocumentIngestionJobTest do
 
       # The job should have been processed
       # drain_jobs returns a map with execution results
-      assert is_map(result)
       assert result.success == 1
       assert result.failure == 0
     end

--- a/test/cake/pipelines_test.exs
+++ b/test/cake/pipelines_test.exs
@@ -121,7 +121,7 @@ defmodule Cake.PipelinesTest do
           version: {1, 18, 3}
         )
 
-      assert is_binary(FailingTestPipeline.success_message(ctx))
+      assert FailingTestPipeline.success_message(ctx) =~ "This should not be called"
     end
 
     test "raises FunctionClauseError when given a raw version string" do


### PR DESCRIPTION
Closes #217. Sub-issue of the epic #205.

`jump_credo_checks` was already a dependency (added in #216), but `Jump.CredoChecks.WeakAssertion` was left disabled — it flagged **19** sites that `assert is_binary/is_list/is_map(...)`, `assert x`, or `assert x != nil`, i.e. that only check a value's *type*, never its content. This PR strengthens every site to assert the specific value/shape, then enables the check as a zero-finding guardrail.

## Commits (each is one checklist item)

| Commit | Bucket | Change | Findings |
|---|---|---|---|
| `398f43e` | 1 | Remove redundant preambles — a stronger assertion already followed on the same value | 19 → 14 |
| `b8e8bf9` | 2a + 2d | `response` equals the mocked/generation text; `pending` pattern-matches the manual-ask map; `extract/2` returns exactly one citation and no hallucinations; `hashed_password` matches the bcrypt `$2[aby]$` prefix | 14 → 9 |
| `7951740` | 2c | Computed strings/maps → assert actual content (prompt-context header, full doc rendering, `success_message` sentinel, `{:auth, body}` error text, `usage` map) | 9 → 4 |
| `0381c25` | 2b | Citation shape-block → pin exact values via an indexed comprehension | 4 → 0 |
| `b8209c5` | — | Enable `Jump.CredoChecks.WeakAssertion` in `.credo.exs`; drop it from the "not enabled" list | check on |

## Bucket 2b decision

The response-shape mock builds citations deterministically from `1..3`, so rather than a loose key-set match the per-citation `Enum.each` type-check block became an indexed `for` comprehension that pins every field to its exact value (`old_index`/`new_index`, `id`, `label`, `preview`, `source_ref`, and the full `extras` map). The values are fully determined by the mock, so this is strong without being brittle.

## Verification

- `mix compile --force --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — exit 0 (remaining output is the pre-existing non-blocking `TagTODO` reminders at `exit_status: 0`); zero WeakAssertion findings
- `mix test --exclude integration` — 631 passed (70 properties, 561 tests)

No implementation code changed — this is a test-assertion + Credo-config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_