### PR TITLE
Fix flaky embeddings tests: pin :embeddings_module in test config (#219)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -51,3 +51,11 @@ config :cake, Cake.Generation.OpenAI,
 config :cake, :books_download_root, System.tmp_dir!()
 
 config :cake, book_storage_adapter: Cake.Books.Adapters.Mock
+
+# Resolve the embeddings collaborator to the Mox mock for the whole test run.
+# The ingestion pipelines read `Application.get_env(:cake, :embeddings_module,
+# Cake.Embeddings)` at call time; setting it here once (immutably) — rather than
+# per-test `put_env`/`delete_env` — avoids a global-state race where one async
+# module's teardown unset the key out from under another's in-flight embedding
+# tasks. Every embedding-exercising test sets its own `Mox.expect`. See #219.
+config :cake, :embeddings_module, Cake.Embeddings.Mock

--- a/test/cake/books/pipeline_test.exs
+++ b/test/cake/books/pipeline_test.exs
@@ -101,12 +101,6 @@ defmodule Cake.Books.PipelineTest do
   end
 
   describe "embedding_status lifecycle" do
-    setup do
-      Application.put_env(:cake, :embeddings_module, Cake.Embeddings.Mock)
-      on_exit(fn -> Application.delete_env(:cake, :embeddings_module) end)
-      :ok
-    end
-
     test "sets :completed when all chunks embed successfully" do
       book = make_book("Good Book", "hash_good_#{System.unique_integer([:positive])}")
       chunk1 = make_chunk("First chunk of text")

--- a/test/cake/jobs/document_ingestion_job_test.exs
+++ b/test/cake/jobs/document_ingestion_job_test.exs
@@ -17,15 +17,8 @@ defmodule Cake.Jobs.DocumentIngestionJobTest do
   setup :verify_on_exit!
 
   setup do
-    # Configure the application to use the mock embeddings module for tests
-    Application.put_env(:cake, :embeddings_module, Mock)
-
     # Set Logger level to info for tests to capture all logs
     Logger.configure(level: :info)
-
-    on_exit(fn ->
-      Application.delete_env(:cake, :embeddings_module)
-    end)
 
     :ok
   end

--- a/test/cake/pipelines_test.exs
+++ b/test/cake/pipelines_test.exs
@@ -25,12 +25,6 @@ defmodule Cake.PipelinesTest do
 
   setup :verify_on_exit!
 
-  setup do
-    Application.put_env(:cake, :embeddings_module, Mock)
-    on_exit(fn -> Application.delete_env(:cake, :embeddings_module) end)
-    :ok
-  end
-
   defp build_ctx(overrides) do
     Pipelines.build_context(
       Keyword.get(overrides, :behaviour, Cake.Documents.Pipeline),


### PR DESCRIPTION
Closes #219.

## Problem

`Cake.Books.PipelineTest` "embedding_status lifecycle sets :processing before embedding begins" fails intermittently in CI (~1/5 runs) with:

```
** (KeyError) key :openai_key not found in: []
    (elixir 1.20.2) lib/keyword.ex:618: Keyword.fetch!/2
    (cake 0.1.0) lib/cake/embeddings.ex:18: Cake.Embeddings.embed/3
    (cake 0.1.0) lib/cake/books/pipeline.ex:243: anonymous fn/4 in Cake.Books.Pipeline.embed_all_chunks/4
```

## Root cause — global-state race across async modules

The ingestion pipelines resolve their embeddings collaborator from a **process-global** application env at call time:

```elixir
# lib/cake/books/pipeline.ex:232, :342 (and documents/pipeline.ex)
embeddings_module = Application.get_env(:cake, :embeddings_module, Cake.Embeddings)
```

Three test modules mutated that one global key in `setup`/`on_exit` — **two of them `async: true`** (`books/pipeline_test`, `pipelines_test`; plus the `async: false` `document_ingestion_job_test`). Because the async modules run concurrently, one module's teardown races the other's in-flight work:

1. `pipeline_test` sets `embeddings_module = Mock`, then `run_ingest` fans embedding out over `Task.async_stream`.
2. Concurrently, a `pipelines_test` test finishes and its `on_exit` runs `Application.delete_env(:cake, :embeddings_module)` — the key is now unset globally.
3. `pipeline_test`'s still-running task reads `get_env(..., Cake.Embeddings)`, gets the **default real module**, and blows up on `Keyword.fetch!([], :openai_key)`.

The `delete_env` is the trigger: even though every module sets the same value, one module's cleanup yanks the key out from under another's async tasks. (The Mock reaches the `Task.async_stream` children via Mox's `$callers` chain, which is why no explicit `allow/3` is needed and why it usually passes.)

## Fix

Set the module **once, immutably, for the whole test run** in `config/test.exs`, and drop the per-test `put_env`/`on_exit delete_env` from all three modules:

```elixir
# config/test.exs
config :cake, :embeddings_module, Cake.Embeddings.Mock
```

The value is now constant for the entire suite — nothing to race.

- Every embedding-exercising test already sets its own `Mox.expect`, so they keep passing.
- Tests that never call embeddings are unaffected.
- Any test that reached the embedding path without an expectation would now surface a clean Mox "no expectation defined" error instead of a real-API/`KeyError` landmine.
- Prod/dev keep the real module via the `get_env/3` default — **no production API changes**.

## Verification

- Full suite (`mix test --exclude integration`) green across seeds `1, 7, 42, 99991, 123456, 31337` — **631 passed** each — with **zero** `pipeline.ex:243` embedding fallbacks (the flake's signature). On `master`, the same runs intermittently hit it.
- `mix format --check-formatted` and `mix credo --strict` (exit 0) both clean.

### Note (out of scope)

A separate, **pre-existing** benign log — one `KeyError :openai_key` from `Cake.Conversation.embed_and_search/2` (`conversation.ex:285`) per full-suite run — is present identically on `master` and is unrelated to the `:embeddings_module` env (`Conversation` injects its embedder via `start_link` opts, defaulting to the real module for an error-path test). It doesn't fail any test. Left untouched here; can be cleaned up separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_