### PR TITLE
Define `Cake.Decomposition` behaviour and `Result` struct (#223)

### DIFF
--- a/lib/cake/decomposition.ex
+++ b/lib/cake/decomposition.ex
@@ -1,0 +1,41 @@
+defmodule Cake.Decomposition do
+  @moduledoc """
+  Behaviour for query-decomposition strategies.
+
+  A strategy inspects a user question and returns a `Cake.Decomposition.Result`
+  describing whether the question is atomic or decomposes into sub-questions.
+  Strategies are pure: question in, sub-questions out. They never touch
+  `Cake.Search` or `Cake.Embeddings` — `Cake.Conversation` performs all
+  retrieval and feeds results back in as data (see the Query Decomposition
+  epic).
+
+  The first implementation is `Cake.Decomposition.LLM`; `Cake.Decomposition.Mock`
+  (Mox) stands in for tests.
+  """
+
+  use Boundary, top_level?: true, deps: [Cake, Cake.Generation], exports: [Result]
+
+  alias Cake.Decomposition.Result
+
+  @typedoc """
+  Why a decomposition attempt failed. Kept small and pattern-matchable, in the
+  same spirit as `t:Cake.Generation.error_reason/0`.
+
+    - `:invalid_response` — the strategy produced output that could not be read
+      as a decomposition (e.g. the LLM returned an unexpected shape).
+    - `:generation` — an underlying generation call failed; the wrapped term is
+      the provider's own error reason.
+  """
+  @type error_reason ::
+          {:invalid_response, String.t()}
+          | {:generation, term()}
+
+  @doc """
+  Decompose `question` into sub-questions.
+
+  Returns `{:ok, Result.t()}` — an atomic question yields a `Result` whose
+  `sub_questions` list is empty — or `{:error, error_reason()}`.
+  """
+  @callback decompose(question :: String.t(), opts :: keyword()) ::
+              {:ok, Result.t()} | {:error, error_reason()}
+end

--- a/lib/cake/decomposition.ex
+++ b/lib/cake/decomposition.ex
@@ -9,8 +9,8 @@ defmodule Cake.Decomposition do
   retrieval and feeds results back in as data (see the Query Decomposition
   epic).
 
-  The first implementation is `Cake.Decomposition.LLM`; `Cake.Decomposition.Mock`
-  (Mox) stands in for tests.
+  The first implementation will be `Cake.Decomposition.LLM` (added in #225);
+  `Cake.Decomposition.Mock` (Mox) stands in for tests.
   """
 
   use Boundary, top_level?: true, deps: [Cake, Cake.Generation], exports: [Result]

--- a/lib/cake/decomposition/result.ex
+++ b/lib/cake/decomposition/result.ex
@@ -1,0 +1,52 @@
+defmodule Cake.Decomposition.Result do
+  @moduledoc """
+  The outcome of decomposing a question.
+
+  `strategy` records how the question was handled:
+
+    - `:none` — atomic; `sub_questions` is empty.
+    - `:flat` — decomposed into an unordered list of independent sub-questions.
+
+  `question_index` maps each sub-question's positional index to its text, so a
+  downstream `Cake.Search.Provenance` can reference a sub-question by index
+  rather than by re-scanning the list. For an atomic result it is empty.
+
+  (Tier 3 of the Query Decomposition epic replaces the flat `sub_questions`
+  list with a DAG representation and adds the `:sequential` strategy; until
+  then the enum is deliberately `:none | :flat`.)
+  """
+
+  @type strategy :: :none | :flat
+
+  @type t :: %__MODULE__{
+          original_question: String.t(),
+          strategy: strategy(),
+          sub_questions: [String.t()],
+          question_index: %{non_neg_integer() => String.t()}
+        }
+
+  @enforce_keys [:original_question]
+  defstruct [
+    :original_question,
+    strategy: :none,
+    sub_questions: [],
+    question_index: %{}
+  ]
+
+  @doc """
+  Build a `Result` from a question and its sub-questions.
+
+  With no sub-questions the result is atomic (`strategy: :none`, empty
+  `sub_questions` and `question_index`). With sub-questions it is
+  `strategy: :flat`, and `question_index` maps `0..length-1` to each
+  sub-question's text.
+  """
+  @spec new(String.t(), [String.t()]) :: t()
+  def new(original_question, sub_questions \\ [])
+
+  # Placeholder: always produces an atomic result. Replaced by the real
+  # constructor once the tests that pin its behaviour are in place.
+  def new(original_question, _sub_questions) when is_binary(original_question) do
+    %__MODULE__{original_question: original_question, strategy: :none}
+  end
+end

--- a/lib/cake/decomposition/result.ex
+++ b/lib/cake/decomposition/result.ex
@@ -44,9 +44,23 @@ defmodule Cake.Decomposition.Result do
   @spec new(String.t(), [String.t()]) :: t()
   def new(original_question, sub_questions \\ [])
 
-  # Placeholder: always produces an atomic result. Replaced by the real
-  # constructor once the tests that pin its behaviour are in place.
-  def new(original_question, _sub_questions) when is_binary(original_question) do
+  def new(original_question, []) when is_binary(original_question) do
     %__MODULE__{original_question: original_question, strategy: :none}
+  end
+
+  def new(original_question, sub_questions)
+      when is_binary(original_question) and is_list(sub_questions) do
+    %__MODULE__{
+      original_question: original_question,
+      strategy: :flat,
+      sub_questions: sub_questions,
+      question_index: build_index(sub_questions)
+    }
+  end
+
+  defp build_index(sub_questions) do
+    sub_questions
+    |> Enum.with_index()
+    |> Map.new(fn {question, index} -> {index, question} end)
   end
 end

--- a/test/cake/decomposition/result_property_test.exs
+++ b/test/cake/decomposition/result_property_test.exs
@@ -1,0 +1,35 @@
+defmodule Cake.Decomposition.ResultPropertyTest do
+  @moduledoc """
+  Structural invariants of `Cake.Decomposition.Result.new/2`.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Cake.Decomposition.Result
+
+  property "sub_questions is always a list and question_index keys are exactly 0..length-1" do
+    check all(
+            question <- StreamData.string(:printable, min_length: 1),
+            sub_questions <- StreamData.list_of(StreamData.string(:printable))
+          ) do
+      result = Result.new(question, sub_questions)
+
+      assert is_list(result.sub_questions)
+      assert result.sub_questions == sub_questions
+
+      expected_keys =
+        case sub_questions do
+          [] -> []
+          list -> Enum.to_list(0..(length(list) - 1))
+        end
+
+      assert result.question_index |> Map.keys() |> Enum.sort() == expected_keys
+
+      # Every index maps back to the sub-question at that position.
+      for {index, text} <- result.question_index do
+        assert Enum.at(sub_questions, index) == text
+      end
+    end
+  end
+end

--- a/test/cake/decomposition/result_test.exs
+++ b/test/cake/decomposition/result_test.exs
@@ -5,9 +5,11 @@ defmodule Cake.Decomposition.ResultTest do
 
   describe "new/2" do
     test "a question with no sub-questions is atomic (strategy :none)" do
-      result = Result.new("What is the boiling point of water?")
+      question = "What is the boiling point of water?"
 
-      assert result.original_question == "What is the boiling point of water?"
+      result = Result.new(question)
+
+      assert result.original_question == question
       assert result.strategy == :none
       assert result.sub_questions == []
       assert result.question_index == %{}
@@ -22,12 +24,16 @@ defmodule Cake.Decomposition.ResultTest do
     end
 
     test "sub-questions yield strategy :flat with a positional index" do
-      result = Result.new("Compare A and B", ["What is A?", "What is B?"])
+      question = "Compare A and B"
+      sub_question_a = "What is A?"
+      sub_question_b = "What is B?"
 
-      assert result.original_question == "Compare A and B"
+      result = Result.new(question, [sub_question_a, sub_question_b])
+
+      assert result.original_question == question
       assert result.strategy == :flat
-      assert result.sub_questions == ["What is A?", "What is B?"]
-      assert result.question_index == %{0 => "What is A?", 1 => "What is B?"}
+      assert result.sub_questions == [sub_question_a, sub_question_b]
+      assert result.question_index == %{0 => sub_question_a, 1 => sub_question_b}
     end
   end
 end

--- a/test/cake/decomposition/result_test.exs
+++ b/test/cake/decomposition/result_test.exs
@@ -1,0 +1,33 @@
+defmodule Cake.Decomposition.ResultTest do
+  use ExUnit.Case, async: true
+
+  alias Cake.Decomposition.Result
+
+  describe "new/2" do
+    test "a question with no sub-questions is atomic (strategy :none)" do
+      result = Result.new("What is the boiling point of water?")
+
+      assert result.original_question == "What is the boiling point of water?"
+      assert result.strategy == :none
+      assert result.sub_questions == []
+      assert result.question_index == %{}
+    end
+
+    test "an explicit empty sub-question list is also atomic" do
+      result = Result.new("q", [])
+
+      assert result.strategy == :none
+      assert result.sub_questions == []
+      assert result.question_index == %{}
+    end
+
+    test "sub-questions yield strategy :flat with a positional index" do
+      result = Result.new("Compare A and B", ["What is A?", "What is B?"])
+
+      assert result.original_question == "Compare A and B"
+      assert result.strategy == :flat
+      assert result.sub_questions == ["What is A?", "What is B?"]
+      assert result.question_index == %{0 => "What is A?", 1 => "What is B?"}
+    end
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,5 +1,6 @@
 Mox.defmock(Cake.Embeddings.Mock, for: Cake.Embeddings.Behaviour)
 Mox.defmock(Cake.Generation.Mock, for: Cake.Generation)
+Mox.defmock(Cake.Decomposition.Mock, for: Cake.Decomposition)
 Mox.defmock(Cake.Responses.Mock, for: Cake.Responses.Behaviour)
 Mox.defmock(Cake.Books.Adapters.Mock, for: Cake.Books.Adapters)
 Mox.defmock(Cake.Search.Backend.Mock, for: Cake.Search.Backend)


### PR DESCRIPTION
Closes #223. Sub-issue of the Query Decomposition epic #221 — the behaviour every decomposition strategy implements, and the struct it returns.

## Commits (TDD)

1. **`82fa741` — scaffold.** `Cake.Decomposition` behaviour (`@callback decompose/2`, `@type error_reason`) + `Cake.Decomposition.Result` struct (`@type t`, `@enforce_keys [:original_question]`, `strategy: :none | :flat`, `sub_questions`, positional `question_index`). Registered as a `Boundary` top-level context with `deps: [Cake, Cake.Generation]` (no `Search`/`Embeddings`), exporting `Result`. `Cake.Decomposition.Mock` added to `test/support/mocks.ex`. `new/2` ships as a placeholder (always atomic).
2. **`1bcea82` — red.** Unit tests (atomic vs. decomposed construction) + a property test (`sub_questions` always a list; `question_index` keys exactly `0..length-1`; each index maps back to its sub-question). The decomposed cases fail against the placeholder.
3. **`3a9286e` — green.** Implement the real `new/2` — empty list → atomic (`:none`); non-empty → `:flat` with the built `question_index`.

## Notes / judgment calls

- **Boundary `deps` include `Cake.Generation`** per the epic's settled decision (the LLM strategy in #225 will call `Generation.complete_json/3`). This module doesn't call it yet; I verified the Boundary compiler (dev/prod) does **not** flag the not-yet-used dependency, so it's declared now to match the epic rather than churned in later.
- **`error_reason` is self-contained** (`{:invalid_response, String.t()} | {:generation, term()}`) — the `:generation` term stays `term()` rather than referencing `Cake.Generation.error_reason()`, keeping the type decoupled until the LLM strategy lands.
- **Docs deferred to #233.** The epic batches all README/CLAUDE.md enumeration updates (behaviours/structs tables, boundary list) into its dedicated docs sub-issue #233, so this PR doesn't touch them.

## Verification

- `MIX_ENV=dev mix compile --force --warnings-as-errors` (Boundary compiler active) — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — exit 0
- `mix test --exclude integration` — **578 tests, 72 properties, 0 failures**

_Toolchain note: run locally on Elixir 1.17.3 (the project supports `~> 1.15`); CI runs the project's pinned toolchain._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_