### PR TITLE
Add decomposition prompt template to `Cake.Prompt` (#224)

### DIFF
--- a/lib/cake/decomposition.ex
+++ b/lib/cake/decomposition.ex
@@ -13,7 +13,7 @@ defmodule Cake.Decomposition do
   `Cake.Decomposition.Mock` (Mox) stands in for tests.
   """
 
-  use Boundary, top_level?: true, deps: [Cake, Cake.Generation], exports: [Result]
+  use Boundary, top_level?: true, deps: [Cake, Cake.Generation, Cake.Prompt], exports: [Result]
 
   alias Cake.Decomposition.Result
 

--- a/lib/cake/prompt.ex
+++ b/lib/cake/prompt.ex
@@ -113,10 +113,10 @@ defmodule Cake.Prompt do
     A question is atomic when it asks one thing about one subject and a single search serves it well. For an atomic question, respond with exactly this JSON:
     {"atomic": true}
 
-    A question decomposes when answering it requires combining the answers to distinct, simpler questions — comparisons, multi-part questions, or questions with embedded prerequisites. For a decomposable question, respond with exactly this JSON shape:
-    {"sub_questions": ["first sub-question", "second sub-question"]}
+    A question decomposes when answering it requires combining the answers to distinct, simpler questions — comparisons, multi-part questions, or questions with embedded prerequisites. For a decomposable question, respond with JSON matching this shape:
+    {"sub_questions": ["<sub-question 1>", "<sub-question 2>"]}
 
-    Each sub-question must be self-contained and independently searchable.
+    Each sub-question must be self-contained and independently searchable. Do not include any keys other than "atomic" or "sub_questions".
     Respond with JSON only — no prose, no code fences.
     """
   end

--- a/lib/cake/prompt.ex
+++ b/lib/cake/prompt.ex
@@ -89,6 +89,21 @@ defmodule Cake.Prompt do
     """
   end
 
+  @doc """
+  Build the messages list for the decomposition LLM call.
+
+  The system prompt instructs the model to analyze the question and answer in
+  JSON: `{"atomic": true}` when the question needs no decomposition, or
+  `{"sub_questions": [...]}` when it does. `Cake.Decomposition.LLM` pairs this
+  with the matching JSON schema and `Cake.Generation.complete_json/3`.
+  """
+  @spec decomposition_prompt(String.t()) :: [message()]
+  def decomposition_prompt(question) when is_binary(question) do
+    # Placeholder: replaced once the tests pinning the message shape are in.
+    _ = question
+    []
+  end
+
   @spec system_message_no_context() :: String.t()
   def system_message_no_context do
     """

--- a/lib/cake/prompt.ex
+++ b/lib/cake/prompt.ex
@@ -95,7 +95,7 @@ defmodule Cake.Prompt do
   The system prompt instructs the model to analyze the question and answer in
   JSON: `{"atomic": true}` when the question needs no decomposition, or
   `{"sub_questions": [...]}` when it does. `Cake.Decomposition.LLM` pairs this
-  with the matching JSON schema and `Cake.Generation.complete_json/3`.
+  with the matching JSON schema and `c:Cake.Generation.complete_json/3`.
   """
   @spec decomposition_prompt(String.t()) :: [message()]
   def decomposition_prompt(question) when is_binary(question) do

--- a/lib/cake/prompt.ex
+++ b/lib/cake/prompt.ex
@@ -99,9 +99,26 @@ defmodule Cake.Prompt do
   """
   @spec decomposition_prompt(String.t()) :: [message()]
   def decomposition_prompt(question) when is_binary(question) do
-    # Placeholder: replaced once the tests pinning the message shape are in.
-    _ = question
-    []
+    [
+      %{role: "system", content: decomposition_system_message()},
+      %{role: "user", content: question}
+    ]
+  end
+
+  @spec decomposition_system_message() :: String.t()
+  def decomposition_system_message do
+    """
+    You analyze a user's question and decide whether it should be decomposed into simpler sub-questions before searching reference documents.
+
+    A question is atomic when it asks one thing about one subject and a single search serves it well. For an atomic question, respond with exactly this JSON:
+    {"atomic": true}
+
+    A question decomposes when answering it requires combining the answers to distinct, simpler questions — comparisons, multi-part questions, or questions with embedded prerequisites. For a decomposable question, respond with exactly this JSON shape:
+    {"sub_questions": ["first sub-question", "second sub-question"]}
+
+    Each sub-question must be self-contained and independently searchable.
+    Respond with JSON only — no prose, no code fences.
+    """
   end
 
   @spec system_message_no_context() :: String.t()
@@ -114,7 +131,7 @@ defmodule Cake.Prompt do
     """
   end
 
-  # TODO: Query decomposition and expansion will go here.
+  # TODO: Query expansion will go here.
   # TODO: Implement exponential memory decay per
   #   https://towardsdatascience.com/rag-isnt-enough-...
   # TODO: Future pass — summarize older history into a compressed preamble

--- a/test/cake/prompt_property_test.exs
+++ b/test/cake/prompt_property_test.exs
@@ -311,4 +311,16 @@ defmodule Cake.PromptPropertyTest do
       assert actual_pairs == expected_pairs
     end
   end
+
+  property "decomposition_prompt/1 is [system, user] with the question verbatim" do
+    check all(question <- string(:printable, min_length: 1)) do
+      assert [
+               %{role: "system", content: system},
+               %{role: "user", content: user}
+             ] = Prompt.decomposition_prompt(question)
+
+      assert user == question
+      assert String.contains?(system, "atomic")
+    end
+  end
 end

--- a/test/cake/prompt_test.exs
+++ b/test/cake/prompt_test.exs
@@ -252,4 +252,27 @@ defmodule Cake.PromptTest do
       refute String.contains?(message, "[1]")
     end
   end
+
+  describe "decomposition_prompt/1" do
+    test "returns a system message followed by the question as the user message" do
+      question = "How does the RO-400 filter compare to the RO-500?"
+
+      assert [%{role: "system", content: system}, %{role: "user", content: ^question}] =
+               Cake.Prompt.decomposition_prompt(question)
+
+      assert String.contains?(system, "JSON")
+    end
+
+    test "system prompt documents the atomic JSON shape" do
+      [%{role: "system", content: system} | _] = Cake.Prompt.decomposition_prompt("q")
+
+      assert String.contains?(system, ~s({"atomic": true}))
+    end
+
+    test "system prompt documents the decomposed JSON shape" do
+      [%{role: "system", content: system} | _] = Cake.Prompt.decomposition_prompt("q")
+
+      assert String.contains?(system, ~s("sub_questions"))
+    end
+  end
 end


### PR DESCRIPTION
Closes #224. Sub-issue of the Query Decomposition epic #221 — the prompt template `Cake.Decomposition.LLM` (#225) will pair with `Generation.complete_json/3`.

## Commits (TDD)

1. **`fca7449` — red.** Failing tests for `Prompt.decomposition_prompt/1`: example tests pin the `[system, user]` shape and that the system prompt mentions JSON and documents both response shapes (`{"atomic": true}` / `"sub_questions"`); a property test pins that for *any* question the result is exactly `[system, user]` with the user content equal to the input verbatim. A minimal stub (with `@spec`) keeps the suite compiling; the assertions fail against its empty return.
2. **`469c635` — green.** Implement the template: system message instructing the model to answer in JSON only (atomic vs. sub-questions, each sub-question self-contained and independently searchable) + the user's question verbatim. System text lives in a public `decomposition_system_message/0`, mirroring the existing `system_message_with_context/1` / `system_message_no_context/0` helpers. Also adds `Cake.Prompt` to `Cake.Decomposition`'s Boundary deps (for #225) and narrows the now-stale "query decomposition and expansion" TODO to expansion only.

## Notes

- **No new Boundary dep for `Cake.Prompt` itself** — the function is pure string assembly, per the sub-issue. The dep added is the *reverse* direction: `Cake.Decomposition` may now call `Cake.Prompt`.
- Prompt engineering stays centralized in `Cake.Prompt`; this is deliberately distinct from `build/4` (the RAG prompt).
- Tests split per house convention: examples in `prompt_test.exs`, the invariant in `prompt_property_test.exs`.

## Verification

- `MIX_ENV=dev mix compile --force --warnings-as-errors` (Boundary compiler active) — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — exit 0
- `mix test --exclude integration` — **581 tests, 73 properties, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_