### PR TITLE
Implement `Cake.Decomposition.LLM` — atomized decomposition via LLM (#225)

### DIFF
--- a/lib/cake/decomposition.ex
+++ b/lib/cake/decomposition.ex
@@ -9,11 +9,14 @@ defmodule Cake.Decomposition do
   retrieval and feeds results back in as data (see the Query Decomposition
   epic).
 
-  The first implementation will be `Cake.Decomposition.LLM` (added in #225);
-  `Cake.Decomposition.Mock` (Mox) stands in for tests.
+  The first implementation is `Cake.Decomposition.LLM`; `Cake.Decomposition.Mock`
+  (Mox) stands in for tests.
   """
 
-  use Boundary, top_level?: true, deps: [Cake, Cake.Generation, Cake.Prompt], exports: [Result]
+  use Boundary,
+    top_level?: true,
+    deps: [Cake, Cake.Generation, Cake.Prompt],
+    exports: [Result, LLM]
 
   alias Cake.Decomposition.Result
 

--- a/lib/cake/decomposition/llm.ex
+++ b/lib/cake/decomposition/llm.ex
@@ -47,15 +47,15 @@ defmodule Cake.Decomposition.LLM do
     end
   end
 
-defp parse_result(_question, %{"atomic" => true, "sub_questions" => _} = parsed) do
-  {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}
-end
+  defp parse_result(_question, %{"atomic" => true, "sub_questions" => _} = parsed) do
+    {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}
+  end
 
-defp parse_result(question, %{"atomic" => true}), do: {:ok, Result.new(question)}
+  defp parse_result(question, %{"atomic" => true}), do: {:ok, Result.new(question)}
 
-defp parse_result(question, %{"sub_questions" => sub_questions}) when is_list(sub_questions) do
-  {:ok, Result.new(question, sub_questions)}
-end
+  defp parse_result(question, %{"sub_questions" => sub_questions}) when is_list(sub_questions) do
+    {:ok, Result.new(question, sub_questions)}
+  end
 
   defp parse_result(_question, parsed) do
     {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}

--- a/lib/cake/decomposition/llm.ex
+++ b/lib/cake/decomposition/llm.ex
@@ -17,14 +17,44 @@ defmodule Cake.Decomposition.LLM do
 
   alias Cake.Decomposition.Result
 
+  @default_generation Cake.Generation.OpenAI
+  @default_model "gpt-4o-mini"
+
+  # Mirrors the response shapes Prompt.decomposition_prompt/1 instructs the
+  # model to produce.
+  @schema %{
+    "type" => "object",
+    "properties" => %{
+      "atomic" => %{"type" => "boolean"},
+      "sub_questions" => %{"type" => "array", "items" => %{"type" => "string"}}
+    },
+    "additionalProperties" => false
+  }
+
   @impl Cake.Decomposition
   @spec decompose(String.t(), keyword()) ::
           {:ok, Result.t()} | {:error, Cake.Decomposition.error_reason()}
   def decompose(question, opts \\ [])
 
-  # Placeholder: replaced once the tests pinning the contract are in place.
   def decompose(question, opts) when is_binary(question) do
-    _ = opts
-    {:error, {:invalid_response, "not implemented"}}
+    generation = Keyword.get(opts, :generation, @default_generation)
+    model = Keyword.get(opts, :model, @default_model)
+    messages = Cake.Prompt.decomposition_prompt(question)
+
+    case generation.complete_json(messages, model, schema: @schema) do
+      {:ok, %{parsed: parsed}} -> parse_result(question, parsed)
+      {:error, reason} -> {:error, {:generation, reason}}
+    end
+  end
+
+  defp parse_result(question, %{"atomic" => true}), do: {:ok, Result.new(question)}
+
+  defp parse_result(question, %{"sub_questions" => sub_questions})
+       when is_list(sub_questions) do
+    {:ok, Result.new(question, sub_questions)}
+  end
+
+  defp parse_result(_question, parsed) do
+    {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}
   end
 end

--- a/lib/cake/decomposition/llm.ex
+++ b/lib/cake/decomposition/llm.ex
@@ -1,0 +1,30 @@
+defmodule Cake.Decomposition.LLM do
+  @moduledoc """
+  LLM-backed implementation of the `Cake.Decomposition` behaviour.
+
+  Builds the decomposition prompt via `Cake.Prompt.decomposition_prompt/1` and
+  sends it through `c:Cake.Generation.complete_json/3` with a JSON schema
+  describing the expected response shape. The validated JSON is parsed into a
+  `Cake.Decomposition.Result`: `{"atomic": true}` yields an atomic result and
+  `{"sub_questions": [...]}` a flat decomposition.
+
+  This module does no HTTP — the LLM call boundary is `Cake.Generation`. The
+  generation module is injected via the `:generation` opt (defaulting to
+  `Cake.Generation.OpenAI`), so tests substitute `Cake.Generation.Mock`.
+  """
+
+  @behaviour Cake.Decomposition
+
+  alias Cake.Decomposition.Result
+
+  @impl Cake.Decomposition
+  @spec decompose(String.t(), keyword()) ::
+          {:ok, Result.t()} | {:error, Cake.Decomposition.error_reason()}
+  def decompose(question, opts \\ [])
+
+  # Placeholder: replaced once the tests pinning the contract are in place.
+  def decompose(question, opts) when is_binary(question) do
+    _ = opts
+    {:error, {:invalid_response, "not implemented"}}
+  end
+end

--- a/lib/cake/decomposition/llm.ex
+++ b/lib/cake/decomposition/llm.ex
@@ -47,12 +47,15 @@ defmodule Cake.Decomposition.LLM do
     end
   end
 
-  defp parse_result(question, %{"atomic" => true}), do: {:ok, Result.new(question)}
+defp parse_result(_question, %{"atomic" => true, "sub_questions" => _} = parsed) do
+  {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}
+end
 
-  defp parse_result(question, %{"sub_questions" => sub_questions})
-       when is_list(sub_questions) do
-    {:ok, Result.new(question, sub_questions)}
-  end
+defp parse_result(question, %{"atomic" => true}), do: {:ok, Result.new(question)}
+
+defp parse_result(question, %{"sub_questions" => sub_questions}) when is_list(sub_questions) do
+  {:ok, Result.new(question, sub_questions)}
+end
 
   defp parse_result(_question, parsed) do
     {:error, {:invalid_response, "unexpected decomposition shape: #{inspect(parsed)}"}}

--- a/test/cake/decomposition/llm_property_test.exs
+++ b/test/cake/decomposition/llm_property_test.exs
@@ -1,0 +1,63 @@
+defmodule Cake.Decomposition.LLMPropertyTest do
+  @moduledoc """
+  Property tests for `Cake.Decomposition.LLM`.
+
+  The core invariant: whatever valid JSON map the generation mock hands back
+  as `parsed`, `decompose/2` returns `{:ok, Result.t()}` or `{:error, _}` —
+  it never crashes on an unexpected shape.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import Mox
+
+  alias Cake.Decomposition.LLM
+  alias Cake.Decomposition.Result
+
+  setup :verify_on_exit!
+
+  defp json_value do
+    StreamData.one_of([
+      StreamData.boolean(),
+      StreamData.integer(),
+      StreamData.string(:printable, max_length: 20),
+      StreamData.list_of(StreamData.string(:printable, max_length: 10), max_length: 3)
+    ])
+  end
+
+  # Arbitrary JSON objects, biased toward the two shapes the schema describes
+  # so both parse paths are exercised alongside the garbage ones.
+  defp parsed_map do
+    StreamData.one_of([
+      StreamData.constant(%{"atomic" => true}),
+      StreamData.map(
+        StreamData.list_of(StreamData.string(:printable, max_length: 20), max_length: 4),
+        &%{"sub_questions" => &1}
+      ),
+      StreamData.map_of(StreamData.string(:printable, max_length: 10), json_value(),
+        max_length: 4
+      )
+    ])
+  end
+
+  property "any valid JSON map from the mock yields {:ok, Result.t()} or {:error, _}" do
+    check all(parsed <- parsed_map()) do
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        {:ok,
+         %{
+           text: Jason.encode!(parsed),
+           finish_reason: :stop,
+           usage: %{input_tokens: 1, output_tokens: 1, total_tokens: 2},
+           model: "test-model",
+           parsed: parsed
+         }}
+      end)
+
+      case LLM.decompose("any question", generation: Cake.Generation.Mock) do
+        {:ok, %Result{} = result} -> assert result.original_question == "any question"
+        {:error, reason} -> assert elem(reason, 0) in [:invalid_response, :generation]
+      end
+    end
+  end
+end

--- a/test/cake/decomposition/llm_test.exs
+++ b/test/cake/decomposition/llm_test.exs
@@ -1,0 +1,97 @@
+defmodule Cake.Decomposition.LLMTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias Cake.Decomposition.LLM
+  alias Cake.Decomposition.Result
+
+  setup :verify_on_exit!
+
+  @question "How does the RO-400 filter compare to the RO-500?"
+
+  defp completion(parsed) do
+    {:ok,
+     %{
+       text: Jason.encode!(parsed),
+       finish_reason: :stop,
+       usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15},
+       model: "test-model",
+       parsed: parsed
+     }}
+  end
+
+  describe "decompose/2" do
+    test "sends the decomposition prompt and a JSON schema to the generation module" do
+      expect(Cake.Generation.Mock, :complete_json, fn messages, _model, opts ->
+        assert messages == Cake.Prompt.decomposition_prompt(@question)
+
+        schema = Keyword.fetch!(opts, :schema)
+        assert schema["type"] == "object"
+        assert Map.has_key?(schema["properties"], "atomic")
+        assert Map.has_key?(schema["properties"], "sub_questions")
+
+        completion(%{"atomic" => true})
+      end)
+
+      assert {:ok, %Result{}} = LLM.decompose(@question, generation: Cake.Generation.Mock)
+    end
+
+    test "an atomic response produces strategy :none with no sub-questions" do
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        completion(%{"atomic" => true})
+      end)
+
+      assert {:ok, result} = LLM.decompose(@question, generation: Cake.Generation.Mock)
+      assert result.original_question == @question
+      assert result.strategy == :none
+      assert result.sub_questions == []
+      assert result.question_index == %{}
+    end
+
+    test "a decomposed response produces strategy :flat with the sub-questions indexed" do
+      sub_question_a = "What are the specs of the RO-400?"
+      sub_question_b = "What are the specs of the RO-500?"
+
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        completion(%{"sub_questions" => [sub_question_a, sub_question_b]})
+      end)
+
+      assert {:ok, result} = LLM.decompose(@question, generation: Cake.Generation.Mock)
+      assert result.original_question == @question
+      assert result.strategy == :flat
+      assert result.sub_questions == [sub_question_a, sub_question_b]
+      assert result.question_index == %{0 => sub_question_a, 1 => sub_question_b}
+    end
+
+    test "an empty sub-question list collapses to an atomic result" do
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        completion(%{"sub_questions" => []})
+      end)
+
+      assert {:ok, result} = LLM.decompose(@question, generation: Cake.Generation.Mock)
+      assert result.strategy == :none
+      assert result.sub_questions == []
+    end
+
+    test "a generation error propagates wrapped in {:generation, reason}" do
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        {:error, {:timeout, 60_000}}
+      end)
+
+      assert {:error, {:generation, {:timeout, 60_000}}} =
+               LLM.decompose(@question, generation: Cake.Generation.Mock)
+    end
+
+    test "valid JSON in an unexpected shape returns {:invalid_response, _}" do
+      expect(Cake.Generation.Mock, :complete_json, fn _messages, _model, _opts ->
+        completion(%{"answer" => "the RO-500 has a higher flow rate"})
+      end)
+
+      assert {:error, {:invalid_response, description}} =
+               LLM.decompose(@question, generation: Cake.Generation.Mock)
+
+      assert description =~ "answer"
+    end
+  end
+end


### PR DESCRIPTION
Closes #225. Sub-issue of the Query Decomposition epic #221 — **delivers tier 1 (atomized decomposition)**, tying together #222's `complete_json/3`, #223's `Result`, and #224's prompt template.

## Commits (TDD)

1. **`1eb997d` — red.** Failing tests with `Cake.Generation.Mock` standing in for the LLM: the call sends `Prompt.decomposition_prompt/1`'s messages + a JSON schema covering `atomic`/`sub_questions`; `{"atomic": true}` → `strategy: :none`; `{"sub_questions": [...]}` → `strategy: :flat` with the positional `question_index` (empty list collapses to atomic); generation errors propagate as `{:error, {:generation, reason}}`; unexpected-but-valid JSON → `{:error, {:invalid_response, _}}`; plus a property test that any valid JSON map from the mock yields `{:ok, Result.t()} | {:error, _}` — never a crash. A compiling stub keeps `--warnings-as-errors` happy.
2. **`32292bf` — green.** Real `decompose/2`: prompt → injected generation module's `complete_json/3` with the schema (`additionalProperties: false`, only `atomic`/`sub_questions`) → parse into `Result` via `Result.new/2`. No HTTP in this module — the LLM call boundary stays `Cake.Generation`.

## Notes / judgment calls

- **Defaults:** `:generation` defaults to `Cake.Generation.OpenAI` (per the sub-issue); I also added a `:model` opt defaulting to `"gpt-4o-mini"`, matching `Conversation`'s response-model default — the sub-issue didn't specify how the model is chosen, and an opt keeps it injectable when #227 wires this into `Conversation`.
- **Boundary export:** added `LLM` to `Cake.Decomposition`'s `exports` (now `[Result, LLM]`), mirroring how `Cake.Generation` exports `OpenAI` — callers will pass `decomposition: Cake.Decomposition.LLM` as a `Conversation` opt in #227, which needs the module referenceable outside the boundary.
- **Property scope:** the mock hands `parsed` maps directly, deliberately bypassing schema validation, so the property exercises shapes the real flow could never see (e.g. `sub_questions` holding non-strings) — the invariant is purely no-crash with a well-formed result tuple.
- Updated the behaviour's moduledoc from "will be added in #225" to present tense (the Copilot-review wording from #235).

## Verification

- `MIX_ENV=dev mix compile --force --warnings-as-errors` (Boundary active) — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — exit 0
- `mix docs --warnings-as-errors` — exit 0 (callback refs use `c:` form)
- `mix test --exclude integration` — **587 tests, 74 properties, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_