### PR TITLE
Extend `Search.Provenance` for decomposition traceability (#226)

### DIFF
--- a/lib/cake/search/provenance.ex
+++ b/lib/cake/search/provenance.ex
@@ -7,6 +7,11 @@ defmodule Cake.Search.Provenance do
   because query decomposition and multi-index search merge results from
   heterogeneous searches into a single list — set-level grouping doesn't
   survive the merge.
+
+  For a decomposed search, `sub_question_index` is the sub-question's
+  positional key in `Cake.Decomposition.Result`'s `question_index`, so
+  citations trace back to a specific sub-question by index rather than by
+  string matching.
   """
 
   @type t :: %__MODULE__{
@@ -14,6 +19,7 @@ defmodule Cake.Search.Provenance do
           query_text: String.t(),
           decomposed: boolean(),
           original_query: String.t() | nil,
+          sub_question_index: non_neg_integer() | nil,
           embedding_model: String.t() | nil
         }
 
@@ -23,6 +29,7 @@ defmodule Cake.Search.Provenance do
     :query_text,
     :embedding_model,
     decomposed: false,
-    original_query: nil
+    original_query: nil,
+    sub_question_index: nil
   ]
 end

--- a/test/cake/search/provenance_test.exs
+++ b/test/cake/search/provenance_test.exs
@@ -1,0 +1,46 @@
+defmodule Cake.Search.ProvenanceTest do
+  use ExUnit.Case, async: true
+
+  alias Cake.Search.Provenance
+
+  describe "sub_question_index" do
+    test "defaults to nil alongside the other decomposition fields" do
+      provenance = %Provenance{search_type: :hybrid, query_text: "q"}
+
+      assert provenance.sub_question_index == nil
+      assert provenance.decomposed == false
+      assert provenance.original_query == nil
+    end
+
+    test "carries a positional index for a decomposed sub-question search" do
+      question = "Compare A and B"
+      sub_question = "What is B?"
+
+      provenance =
+        struct!(Provenance,
+          search_type: :hybrid,
+          query_text: sub_question,
+          decomposed: true,
+          original_query: question,
+          sub_question_index: 1
+        )
+
+      assert provenance.sub_question_index == 1
+      assert provenance.query_text == sub_question
+      assert provenance.original_query == question
+    end
+
+    test "index zero is a valid position" do
+      provenance =
+        struct!(Provenance,
+          search_type: :vector,
+          query_text: "What is A?",
+          decomposed: true,
+          original_query: "Compare A and B",
+          sub_question_index: 0
+        )
+
+      assert provenance.sub_question_index == 0
+    end
+  end
+end


### PR DESCRIPTION
Closes #226. Sub-issue of the Query Decomposition epic #221 — the schema half of decomposition traceability. The wiring that populates the field during sub-question searches lands with the tier-2 `Conversation` integration (#227).

## Commits (TDD)

1. **`c19939e` — red.** New `test/cake/search/provenance_test.exs`: `sub_question_index` defaults to `nil` alongside the existing decomposition fields; carries a positional index (including zero) for a decomposed sub-question search; coexists with `query_text`/`original_query`. Built via `struct!/2` so the suite compiles and fails at runtime against the current struct.
2. **`ddac646` — green.** Add `sub_question_index :: non_neg_integer() | nil` (default `nil`) to the struct and `@type t`, plus a moduledoc sentence documenting that it keys into `Decomposition.Result`'s `question_index`. No existing fields change.

## Notes

- **No generator to update.** The sub-issue said to update the provenance StreamData generator *if one exists* — none does; test files build `Provenance` via static per-file helpers, which a defaulted field doesn't disturb.
- **The `decomposed: true ⇒ non-nil index` property is deferred**, deliberately: the bare struct can't enforce that invariant (any field combination is constructible) — it's a property of how `Conversation` constructs provenance, so it belongs to #227's tests and the #228 end-to-end traceability property suite, where the epic already places it.
- `Provenance`'s `decomposed`/`original_query` fields were forward-designed for this epic; this completes the trio.

## Verification

- `MIX_ENV=dev mix compile --force --warnings-as-errors` (Boundary active) — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — exit 0
- `mix docs --warnings-as-errors` — exit 0
- `mix test --exclude integration` — **590 tests, 74 properties, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_