### PR TITLE
Run decomposed sub-question searches concurrently (#240)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,6 +52,12 @@ config :cake, Cake.Conversation,
   response_model: "gpt-4o-mini",
   provider: :openai
 
+# Concurrency cap for decomposed sub-question searches within one turn.
+# Each sub-search is an embedding call plus a search-backend query, so the
+# provider rate limit is the real ceiling. Set to 1 to force sequential
+# fan-out in constrained environments (e.g. Colima's default FD limits).
+config :cake, :max_sub_search_concurrency, 4
+
 # Filesystem root that book downloads must resolve under. BooksController
 # refuses to serve any ParsedBook whose source_file_path escapes this directory,
 # so a poisoned/buggy path in the DB can't be used to read arbitrary files.

--- a/lib/cake/conversation.ex
+++ b/lib/cake/conversation.ex
@@ -31,6 +31,15 @@ defmodule Cake.Conversation do
   `Cake.Search.Provenance` is stamped with `decomposed: true`, the
   `original_query`, and its `sub_question_index`.
 
+  Sub-question searches fan out concurrently under `Cake.TaskSupervisor`,
+  capped by `config :cake, :max_sub_search_concurrency` (default 4; set to
+  1 to force sequential fan-out in constrained environments). Each
+  sub-search must finish within `config :cake, :sub_search_timeout`
+  (default 30s). Failure handling is all-or-nothing: any sub-search error,
+  timeout (`:sub_search_timeout`), or crash
+  (`{:sub_search_crashed, reason}`) fails the whole turn, reporting the
+  lowest-index failure — there is no partial context.
+
   ## Dependencies
 
   Search, embeddings, generation, responses, and (optionally) decomposition

--- a/lib/cake/conversation.ex
+++ b/lib/cake/conversation.ex
@@ -64,6 +64,9 @@ defmodule Cake.Conversation do
 
   require Logger
 
+  @default_max_sub_search_concurrency 4
+  @default_sub_search_timeout :timer.seconds(30)
+
   @spec child_spec(map()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
@@ -223,8 +226,9 @@ defmodule Cake.Conversation do
   end
 
   # An atomic decomposition takes the same single-search path as no
-  # decomposition at all; a decomposed one searches each sub-question in
-  # index order, halting on the first error.
+  # decomposition at all; a decomposed one searches every sub-question
+  # concurrently, all-or-nothing: any sub-search error or timeout fails the
+  # turn, reporting the lowest-index failure.
   defp search_decomposed(%Cake.Decomposition.Result{sub_questions: []} = decomposition, s) do
     embed_and_search(decomposition.original_question, s)
   end
@@ -235,21 +239,50 @@ defmodule Cake.Conversation do
     end
   end
 
+  # Fan-out reuses the shared Cake.TaskSupervisor (the turn task's home). If
+  # decomposition ever climbs above ~5 sub-questions per turn, give
+  # sub-search fan-out a dedicated Task.Supervisor so it can't starve turn
+  # tasks.
   defp search_sub_questions(decomposition, s) do
     result =
-      decomposition.question_index
-      |> Enum.sort_by(fn {index, _sub_question} -> index end)
-      |> Enum.reduce_while({:ok, []}, fn {index, sub_question}, {:ok, groups} ->
-        case embed_and_search(sub_question, s) do
-          {:ok, results} ->
-            {:cont, {:ok, [stamp_decomposition(results, decomposition, index) | groups]}}
-
-          {:error, _} = error ->
-            {:halt, error}
-        end
-      end)
+      Cake.TaskSupervisor
+      |> Task.Supervisor.async_stream_nolink(
+        Enum.sort_by(decomposition.question_index, fn {index, _sub_question} -> index end),
+        fn {index, sub_question} ->
+          with {:ok, results} <- embed_and_search(sub_question, s) do
+            {:ok, stamp_decomposition(results, decomposition, index)}
+          end
+        end,
+        ordered: true,
+        max_concurrency: max_sub_search_concurrency(),
+        timeout: sub_search_timeout(),
+        on_timeout: :kill_task
+      )
+      |> Enum.reduce_while({:ok, []}, &collect_sub_search/2)
 
     with {:ok, groups} <- result, do: {:ok, Enum.reverse(groups)}
+  end
+
+  # `ordered: true` yields task outcomes in question_index order, so the
+  # first non-ok outcome is the lowest-index failure; halting also shuts
+  # down the still-running sibling tasks.
+  defp collect_sub_search({:ok, {:ok, group}}, {:ok, groups}),
+    do: {:cont, {:ok, [group | groups]}}
+
+  defp collect_sub_search({:ok, {:error, _} = error}, _acc), do: {:halt, error}
+  defp collect_sub_search({:exit, :timeout}, _acc), do: {:halt, {:error, :sub_search_timeout}}
+
+  defp collect_sub_search({:exit, reason}, _acc),
+    do: {:halt, {:error, {:sub_search_crashed, reason}}}
+
+  defp max_sub_search_concurrency do
+    Application.get_env(:cake, :max_sub_search_concurrency, @default_max_sub_search_concurrency)
+  end
+
+  # JC-1 fixed the production ceiling at 30s; the config read exists so
+  # tests can shrink it to trigger the timeout path deterministically.
+  defp sub_search_timeout do
+    Application.get_env(:cake, :sub_search_timeout, @default_sub_search_timeout)
   end
 
   defp stamp_decomposition([], _decomposition, _index), do: []

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -46,6 +46,22 @@ defmodule Cake.ConversationTest do
     :ok
   end
 
+  # Sets an app-env override for the duration of the test, restoring the
+  # pre-test value on exit — or deleting the key if it was previously unset —
+  # so overrides can't leak into later tests. fetch_env/2 (not get_env/2)
+  # keeps a key stored as nil distinguishable from an absent key.
+  defp put_temporary_env(key, value) do
+    original = Application.fetch_env(:cake, key)
+    Application.put_env(:cake, key, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, original_value} -> Application.put_env(:cake, key, original_value)
+        :error -> Application.delete_env(:cake, key)
+      end
+    end)
+  end
+
   defp test_provenance, do: %Provenance{search_type: :hybrid, query_text: "test"}
 
   defp wrap_result(unit, opts \\ []) do
@@ -1754,8 +1770,7 @@ defmodule Cake.ConversationTest do
     end
 
     test "a timed-out sub-question search fails the turn" do
-      Application.put_env(:cake, :sub_search_timeout, 50)
-      on_exit(fn -> Application.delete_env(:cake, :sub_search_timeout) end)
+      put_temporary_env(:sub_search_timeout, 50)
 
       question = "How does the RO-400 flow rate compare to the RO-500?"
       sub_a = "What is the flow rate of the RO-400?"
@@ -1844,8 +1859,7 @@ defmodule Cake.ConversationTest do
     end
 
     test "max_sub_search_concurrency: 1 forces sequential sub-searches" do
-      Application.put_env(:cake, :max_sub_search_concurrency, 1)
-      on_exit(fn -> Application.delete_env(:cake, :max_sub_search_concurrency) end)
+      put_temporary_env(:max_sub_search_concurrency, 1)
 
       question = "How does the RO-400 flow rate compare to the RO-500?"
       sub_a = "What is the flow rate of the RO-400?"

--- a/test/cake/conversation_test.exs
+++ b/test/cake/conversation_test.exs
@@ -1694,4 +1694,218 @@ defmodule Cake.ConversationTest do
       assert Conversation.merge_decomposed_results([[], []]) == []
     end
   end
+
+  describe "concurrent sub-question fan-out" do
+    test "sub-question searches run concurrently" do
+      question = "How does the RO-400 flow rate compare to the RO-500?"
+      sub_a = "What is the flow rate of the RO-400?"
+      sub_b = "What is the flow rate of the RO-500?"
+      test_pid = self()
+
+      expect(Cake.Decomposition.Mock, :decompose, fn ^question, _opts ->
+        {:ok, Cake.Decomposition.Result.new(question, [sub_a, sub_b])}
+      end)
+
+      # Each embed announces itself and then blocks until the test releases
+      # it. Receiving BOTH announcements while neither embed has been
+      # released is only possible if the sub-searches run concurrently.
+      expect(Cake.Embeddings.Mock, :embed, 2, fn :openai, %{input: input}, _model ->
+        send(test_pid, {:embed_started, input, self()})
+
+        receive do
+          :release -> {:ok, %{attrs: %{embedding: [0.1, 0.2, 0.3]}}}
+        end
+      end)
+
+      stub(Cake.Search.Backend.Mock, :search, fn _query ->
+        {:ok, [build_search_hit(id: "unit-a", body: "flow rate chunk")]}
+      end)
+
+      expect(Cake.Responses.Mock, :process, fn _raw, _indexed, _opts ->
+        %Cake.Responses.Result{
+          raw_text: "answer",
+          final_text: "answer",
+          chunk_map: %{},
+          citations: [],
+          warnings: []
+        }
+      end)
+
+      pid = start_subscribed(%{decomposition: Cake.Decomposition.Mock})
+
+      stub(Cake.Generation.Mock, :complete, fn _messages, _model, _opts ->
+        {:ok, %{text: "answer", usage: %{}}}
+      end)
+
+      allow(Cake.Decomposition.Mock, self(), pid)
+      allow(Cake.Embeddings.Mock, self(), pid)
+      allow(Cake.Search.Backend.Mock, self(), pid)
+      allow(Cake.Responses.Mock, self(), pid)
+      allow(Cake.Generation.Mock, self(), pid)
+
+      assert :ok = Conversation.autoask(pid, question)
+
+      assert_receive {:embed_started, _first, embedder_a}
+      assert_receive {:embed_started, _second, embedder_b}
+      send(embedder_a, :release)
+      send(embedder_b, :release)
+
+      assert_receive {:response_ready, %{response: "answer"}}
+    end
+
+    test "a timed-out sub-question search fails the turn" do
+      Application.put_env(:cake, :sub_search_timeout, 50)
+      on_exit(fn -> Application.delete_env(:cake, :sub_search_timeout) end)
+
+      question = "How does the RO-400 flow rate compare to the RO-500?"
+      sub_a = "What is the flow rate of the RO-400?"
+      sub_b = "What is the flow rate of the RO-500?"
+
+      expect(Cake.Decomposition.Mock, :decompose, fn ^question, _opts ->
+        {:ok, Cake.Decomposition.Result.new(question, [sub_a, sub_b])}
+      end)
+
+      # Never released: with the 50ms config ceiling, the sub-searches
+      # exceed their budget and the turn must fail.
+      stub(Cake.Embeddings.Mock, :embed, fn :openai, _params, _model ->
+        receive do
+          :release -> {:ok, %{attrs: %{embedding: [0.1, 0.2, 0.3]}}}
+        end
+      end)
+
+      pid = start_subscribed(%{decomposition: Cake.Decomposition.Mock})
+
+      allow(Cake.Decomposition.Mock, self(), pid)
+      allow(Cake.Embeddings.Mock, self(), pid)
+
+      assert :ok = Conversation.autoask(pid, question)
+
+      assert_receive {:error, :sub_search_timeout}
+      assert_receive {:state_change, :idle}
+    end
+
+    test "one failing sub-search fails the turn even when the others succeed" do
+      question = "How does the RO-400 flow rate compare to the RO-500?"
+      sub_a = "What is the flow rate of the RO-400?"
+      sub_b = "What is the flow rate of the RO-500?"
+
+      expect(Cake.Decomposition.Mock, :decompose, fn ^question, _opts ->
+        {:ok, Cake.Decomposition.Result.new(question, [sub_a, sub_b])}
+      end)
+
+      stub(Cake.Embeddings.Mock, :embed, fn :openai, %{input: input}, _model ->
+        case input do
+          ^sub_a -> {:ok, %{attrs: %{embedding: [0.1, 0.2, 0.3]}}}
+          ^sub_b -> {:error, :embed_failed_b}
+        end
+      end)
+
+      stub(Cake.Search.Backend.Mock, :search, fn _query ->
+        {:ok, [build_search_hit(id: "unit-a", body: "flow rate chunk")]}
+      end)
+
+      pid = start_subscribed(%{decomposition: Cake.Decomposition.Mock})
+
+      allow(Cake.Decomposition.Mock, self(), pid)
+      allow(Cake.Embeddings.Mock, self(), pid)
+      allow(Cake.Search.Backend.Mock, self(), pid)
+
+      assert :ok = Conversation.autoask(pid, question)
+
+      assert_receive {:error, :embed_failed_b}
+      assert_receive {:state_change, :idle}
+    end
+
+    test "when several sub-searches fail, the lowest-index error is reported" do
+      question = "How does the RO-400 flow rate compare to the RO-500?"
+      sub_a = "What is the flow rate of the RO-400?"
+      sub_b = "What is the flow rate of the RO-500?"
+
+      expect(Cake.Decomposition.Mock, :decompose, fn ^question, _opts ->
+        {:ok, Cake.Decomposition.Result.new(question, [sub_a, sub_b])}
+      end)
+
+      stub(Cake.Embeddings.Mock, :embed, fn :openai, %{input: input}, _model ->
+        case input do
+          ^sub_a -> {:error, :embed_failed_a}
+          ^sub_b -> {:error, :embed_failed_b}
+        end
+      end)
+
+      pid = start_subscribed(%{decomposition: Cake.Decomposition.Mock})
+
+      allow(Cake.Decomposition.Mock, self(), pid)
+      allow(Cake.Embeddings.Mock, self(), pid)
+
+      assert :ok = Conversation.autoask(pid, question)
+
+      assert_receive {:error, :embed_failed_a}
+      assert_receive {:state_change, :idle}
+    end
+
+    test "max_sub_search_concurrency: 1 forces sequential sub-searches" do
+      Application.put_env(:cake, :max_sub_search_concurrency, 1)
+      on_exit(fn -> Application.delete_env(:cake, :max_sub_search_concurrency) end)
+
+      question = "How does the RO-400 flow rate compare to the RO-500?"
+      sub_a = "What is the flow rate of the RO-400?"
+      sub_b = "What is the flow rate of the RO-500?"
+      test_pid = self()
+
+      expect(Cake.Decomposition.Mock, :decompose, fn ^question, _opts ->
+        {:ok, Cake.Decomposition.Result.new(question, [sub_a, sub_b])}
+      end)
+
+      expect(Cake.Embeddings.Mock, :embed, 2, fn :openai, %{input: input}, _model ->
+        send(test_pid, {:embed_started, input, self()})
+
+        receive do
+          :release -> {:ok, %{attrs: %{embedding: [0.1, 0.2, 0.3]}}}
+        end
+      end)
+
+      stub(Cake.Search.Backend.Mock, :search, fn _query ->
+        {:ok, [build_search_hit(id: "unit-a", body: "flow rate chunk")]}
+      end)
+
+      expect(Cake.Responses.Mock, :process, fn _raw, _indexed, _opts ->
+        %Cake.Responses.Result{
+          raw_text: "answer",
+          final_text: "answer",
+          chunk_map: %{},
+          citations: [],
+          warnings: []
+        }
+      end)
+
+      pid = start_subscribed(%{decomposition: Cake.Decomposition.Mock})
+
+      stub(Cake.Generation.Mock, :complete, fn _messages, _model, _opts ->
+        {:ok, %{text: "answer", usage: %{}}}
+      end)
+
+      allow(Cake.Decomposition.Mock, self(), pid)
+      allow(Cake.Embeddings.Mock, self(), pid)
+      allow(Cake.Search.Backend.Mock, self(), pid)
+      allow(Cake.Responses.Mock, self(), pid)
+      allow(Cake.Generation.Mock, self(), pid)
+
+      assert :ok = Conversation.autoask(pid, question)
+
+      assert_receive {:embed_started, first_input, first_embedder}
+      assert first_input == sub_a
+
+      # With the cap at 1, the second sub-search must not start while the
+      # first is still in flight.
+      refute_receive {:embed_started, _input, _pid}, 100
+
+      send(first_embedder, :release)
+
+      assert_receive {:embed_started, second_input, second_embedder}
+      assert second_input == sub_b
+      send(second_embedder, :release)
+
+      assert_receive {:response_ready, %{response: "answer"}}
+    end
+  end
 end


### PR DESCRIPTION
Closes #240

Swaps the sequential per-sub-question search loop from #227 for concurrent fan-out via `Task.Supervisor.async_stream_nolink/4`. All five judgment calls were answered by the dev before implementation and are recorded on the issue thread ([#240 comment](https://github.com/Thoth-Software/cake/issues/240#issuecomment-5274126579)); this PR encodes them.

## What changed

- **Concurrent fan-out (JC-3/JC-4).** `search_sub_questions/2` now runs one task per sub-question under the shared `Cake.TaskSupervisor` with `ordered: true`, capped by `config :cake, :max_sub_search_concurrency` (default 4, set in `config.exs`). Setting the cap to 1 forces sequential execution (JC-5) — pinned by test. A code note marks the JC-4 follow-up: a dedicated Task.Supervisor if decomposition climbs above ~5 sub-questions per turn.
- **Timeout (JC-1).** Each sub-search must finish within 30s (`on_timeout: :kill_task`); a timeout fails the turn with `{:error, :sub_search_timeout}`. The ceiling reads `config :cake, :sub_search_timeout` purely as a test seam — the production default honors the 30s decision.
- **All-or-nothing (JC-2).** Outcomes are collected in `question_index` order, so the first non-ok outcome is the lowest-index failure; halting the collection also shuts down still-running sibling tasks. Any error, timeout, or crash fails the whole turn — no partial context.
- **Unchanged.** Provenance stamping, `merge_decomposed_results/1`, the atomic path, and the `decomposition: nil` path are untouched; ordered collection keeps the merge deterministic, so all #227 tests pass unmodified.

## Tests

- **Rendezvous concurrency proof** (no `Process.sleep`): each embed mock announces itself then blocks until released; the test receives *both* announcements while neither embed has been released — only possible under concurrent execution.
- **Timeout**: config-shrunk 50ms ceiling, never-released embeds → `{:error, :sub_search_timeout}` broadcast.
- **All-or-nothing pins**: one failing sub-search fails the turn even when others succeed; with several failures the lowest-index error is reported.
- **Sequential knob pin**: with the cap at 1, the second sub-search provably does not start until the first is released, and execution follows index order.

## Judgment calls made during implementation (beyond the recorded JCs)

- **Timeout as config read**: JC-1 fixed 30s, but a hardcoded 30s ceiling is untestable; the config key exists so the test can shrink it. Default in code, not in `config.exs`.
- **Crash mapping**: a raising sub-search task now surfaces as `{:error, {:sub_search_crashed, reason}}` instead of crashing the turn task (a behavior change only observable inside the decomposed path; either way the turn fails and `{:error, _}` is broadcast).
- **README staleness**: the README still describes query decomposition as "planned (would live in `Prompt`)" — stale epic-wide since tier 1, deferred to #233 per the epic rather than patched piecemeal here.

## Gates

`mix compile --force --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (baseline only — the new `assert_receive` calls use ExUnit's configured default timeout per the jump_credo_checks rule), `mix docs --warnings-as-errors`, `mix test --exclude integration`: 78 properties, 603 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_