### PR TITLE
Pin decomposition-aware citation traceability invariants as property tests (#228)

### DIFF
--- a/test/cake/decomposition_traceability_property_test.exs
+++ b/test/cake/decomposition_traceability_property_test.exs
@@ -1,0 +1,143 @@
+defmodule Cake.DecompositionTraceabilityPropertyTest do
+  @moduledoc """
+  End-to-end traceability invariants for the decomposition pipeline (#228):
+  from `Cake.Decomposition.Result` through merged retrieval through
+  `Cake.Responses.process/3` citations.
+
+  These are characterization properties over the already-built tiers 1–2
+  pipeline. The harness mirrors the auto-mode back half deterministically:
+  per-sub-question result groups (from `Cake.DecompositionGenerators`) are
+  merged with `Cake.Conversation.merge_decomposed_results/1`, indexed
+  densely 1..N the way the select stage indexes context, and processed with
+  arbitrary LLM response text containing valid and hallucinated `[N]`
+  markers.
+
+  Invariants:
+
+    1. Every citation traces back to a `Search.Result` whose
+       `Provenance.sub_question_index` is a valid key in the decomposition's
+       `question_index` (and whose `original_query` is the original
+       question).
+    2. Every sub-question that contributed at least one result to the
+       merged context surfaces in the processed result's `chunk_map` — no
+       contributing sub-question is silently lost, even when uncited.
+    3. No citation references a prompt index absent from the `chunk_map`;
+       out-of-map indices surface as `:hallucinated_citation` warnings
+       instead.
+    4. For non-decomposed retrieval, every `Provenance` is
+       `decomposed: false` with no `sub_question_index`, end to end.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import Cake.DecompositionGenerators
+
+  alias Cake.Conversation
+  alias Cake.Responses
+  alias Cake.Search.Result
+
+  # The hallucinated-marker generator makes Citations.extract log its
+  # expected warning hundreds of times per run; capture keeps suite output
+  # readable while still printing logs for failing runs.
+  @moduletag capture_log: true
+
+  # Mirrors the select stage's dense 1..N indexing over the merged context.
+  defp index_chunks(merged) do
+    merged
+    |> Enum.with_index(1)
+    |> Enum.map(fn {result, idx} -> {idx, result} end)
+  end
+
+  defp sub_question_indices(results) do
+    MapSet.new(results, fn %Result{provenance: p} -> p.sub_question_index end)
+  end
+
+  property "every citation traces to a sub-question in the decomposition's question_index" do
+    check all(
+            {decomposition, groups} <- decomposed_retrieval(),
+            text <- response_text()
+          ) do
+      indexed = groups |> Conversation.merge_decomposed_results() |> index_chunks()
+      by_index = Map.new(indexed)
+
+      result = Responses.process(text, indexed, [])
+
+      Enum.each(result.citations, fn citation ->
+        %Result{provenance: provenance, retrieval_unit: unit} =
+          Map.fetch!(by_index, citation.old_index)
+
+        assert Map.has_key?(decomposition.question_index, provenance.sub_question_index)
+        assert provenance.original_query == decomposition.original_question
+        assert provenance.decomposed == true
+        assert citation.id == Cake.Citable.metadata(unit).id
+      end)
+    end
+  end
+
+  property "every sub-question contributing to the merged context surfaces in the chunk_map" do
+    check all(
+            {_decomposition, groups} <- decomposed_retrieval(),
+            text <- response_text()
+          ) do
+      merged = Conversation.merge_decomposed_results(groups)
+      indexed = index_chunks(merged)
+      by_index = Map.new(indexed)
+
+      result = Responses.process(text, indexed, [])
+
+      surfaced =
+        result.chunk_map
+        |> Map.keys()
+        |> MapSet.new(fn idx -> Map.fetch!(by_index, idx).provenance.sub_question_index end)
+
+      assert surfaced == sub_question_indices(merged)
+    end
+  end
+
+  property "no citation references a prompt index absent from the chunk_map" do
+    check all(
+            {_decomposition, groups} <- decomposed_retrieval(),
+            text <- response_text()
+          ) do
+      indexed = groups |> Conversation.merge_decomposed_results() |> index_chunks()
+
+      result = Responses.process(text, indexed, [])
+
+      Enum.each(result.citations, fn citation ->
+        assert Map.has_key?(result.chunk_map, citation.old_index)
+      end)
+
+      hallucinated = for {:hallucinated_citation, idx} <- result.warnings, do: idx
+
+      Enum.each(hallucinated, fn idx ->
+        refute Map.has_key?(result.chunk_map, idx)
+      end)
+    end
+  end
+
+  property "non-decomposed retrieval carries decomposed: false provenance end to end" do
+    check all(
+            results <- plain_results(),
+            text <- response_text()
+          ) do
+      indexed = index_chunks(results)
+      by_index = Map.new(indexed)
+
+      result = Responses.process(text, indexed, [])
+
+      Enum.each(indexed, fn {_idx, %Result{provenance: provenance}} ->
+        assert provenance.decomposed == false
+        assert provenance.sub_question_index == nil
+        assert provenance.original_query == nil
+      end)
+
+      Enum.each(result.citations, fn citation ->
+        assert Map.has_key?(result.chunk_map, citation.old_index)
+
+        assert citation.id ==
+                 Cake.Citable.metadata(Map.fetch!(by_index, citation.old_index).retrieval_unit).id
+      end)
+    end
+  end
+end

--- a/test/support/decomposition_generators.ex
+++ b/test/support/decomposition_generators.ex
@@ -1,0 +1,159 @@
+defmodule Cake.DecompositionGenerators do
+  @moduledoc """
+  StreamData generators for decomposition-aware traceability property tests.
+
+  Generators return `StreamData.t(value)` and compose with standard
+  StreamData combinators. The central generator is `decomposed_retrieval/0`,
+  which produces a `Cake.Decomposition.Result` together with the
+  per-sub-question `Cake.Search.Result` groups the tier-2 pipeline would
+  have retrieved for it: one group per `question_index` entry, every result
+  stamped with matching decomposition provenance, and retrieval-unit IDs
+  drawn from a shared pool so duplicates across sub-questions (the merge's
+  dedup case) are common.
+
+  Retrieval units are `Cake.Test.ConvoChunk` structs, so generated results
+  flow through `Cake.Citable`/`Cake.Promptable` exactly like the pipeline's
+  own.
+  """
+
+  alias Cake.Search.Provenance
+  alias Cake.Search.Result
+  alias Cake.Test.ConvoChunk
+
+  @max_citation_index 12
+
+  @doc "Generates non-empty printable question strings."
+  @spec question() :: StreamData.t(String.t())
+  def question do
+    StreamData.string(:printable, min_length: 1, max_length: 40)
+  end
+
+  @doc "Generates 1..4 distinct sub-question strings."
+  @spec sub_questions() :: StreamData.t([String.t()])
+  def sub_questions do
+    StreamData.uniq_list_of(
+      StreamData.string(:printable, min_length: 1, max_length: 30),
+      min_length: 1,
+      max_length: 4
+    )
+  end
+
+  @doc "Generates decomposed `Cake.Decomposition.Result` structs (strategy :flat)."
+  @spec decomposition_result() :: StreamData.t(Cake.Decomposition.Result.t())
+  def decomposition_result do
+    StreamData.bind(question(), fn q ->
+      StreamData.map(sub_questions(), fn subs -> Cake.Decomposition.Result.new(q, subs) end)
+    end)
+  end
+
+  @doc """
+  Generates `{decomposition, groups}` pairs: a decomposed
+  `Cake.Decomposition.Result` plus one `Cake.Search.Result` list per
+  `question_index` entry (possibly empty), each result carrying provenance
+  stamped with `decomposed: true`, the decomposition's original question,
+  the sub-question's text, and its index.
+  """
+  @spec decomposed_retrieval() ::
+          StreamData.t({Cake.Decomposition.Result.t(), [[Result.t()]]})
+  def decomposed_retrieval do
+    StreamData.bind(decomposition_result(), fn decomposition ->
+      StreamData.bind(unit_id_pool(), fn pool ->
+        group_count = map_size(decomposition.question_index)
+
+        per_group =
+          StreamData.list_of(
+            StreamData.tuple({StreamData.member_of(pool), relevance_score()}),
+            max_length: 5
+          )
+
+        StreamData.map(
+          StreamData.list_of(per_group, length: group_count),
+          fn id_score_groups -> {decomposition, build_groups(decomposition, id_score_groups)} end
+        )
+      end)
+    end)
+  end
+
+  @doc """
+  Generates non-decomposed retrieval contexts: `Cake.Search.Result` lists
+  with distinct retrieval-unit IDs whose provenance relies on
+  `Cake.Search.Provenance` struct defaults for every decomposition field.
+  """
+  @spec plain_results() :: StreamData.t([Result.t()])
+  def plain_results do
+    StreamData.bind(unit_id_pool(), fn pool ->
+      StreamData.map(
+        StreamData.list_of(relevance_score(), length: length(pool)),
+        fn scores ->
+          pool
+          |> Enum.zip(scores)
+          |> Enum.map(fn {id, score} ->
+            search_result(id, score, %Provenance{search_type: :hybrid, query_text: "plain"})
+          end)
+        end
+      )
+    end)
+  end
+
+  @doc """
+  Generates LLM response text: words interleaved with `[N]` citation
+  markers, `N` in `1..#{@max_citation_index}`. Markers beyond the indexed
+  context's size exercise the hallucinated-citation path.
+  """
+  @spec response_text() :: StreamData.t(String.t())
+  def response_text do
+    segment =
+      StreamData.one_of([
+        StreamData.string(:alphanumeric, min_length: 1, max_length: 8),
+        StreamData.map(StreamData.integer(1..@max_citation_index), &"[#{&1}]")
+      ])
+
+    StreamData.map(StreamData.list_of(segment, max_length: 12), &Enum.join(&1, " "))
+  end
+
+  defp unit_id_pool do
+    StreamData.uniq_list_of(
+      StreamData.string(:alphanumeric, min_length: 1, max_length: 8),
+      min_length: 1,
+      max_length: 6
+    )
+  end
+
+  defp relevance_score do
+    StreamData.float(min: 0.0, max: 1.0)
+  end
+
+  defp build_groups(decomposition, id_score_groups) do
+    id_score_groups
+    |> Enum.with_index()
+    |> Enum.map(fn {id_scores, index} ->
+      provenance = decomposed_provenance(decomposition, index)
+      Enum.map(id_scores, fn {id, score} -> search_result(id, score, provenance) end)
+    end)
+  end
+
+  defp decomposed_provenance(decomposition, index) do
+    %Provenance{
+      search_type: :hybrid,
+      query_text: Map.fetch!(decomposition.question_index, index),
+      decomposed: true,
+      original_query: decomposition.original_question,
+      sub_question_index: index
+    }
+  end
+
+  defp search_result(id, score, provenance) do
+    %Result{
+      retrieval_unit: %ConvoChunk{
+        embedding: [0.1, 0.2, 0.3],
+        prompt_text: "chunk #{id}",
+        metadata: %{id: id, label: "L-#{id}", preview: "p-#{id}", source_ref: nil, extras: %{}}
+      },
+      backend_score: 1.0,
+      relevance_score: score,
+      hit_source: :search,
+      index: "test_index",
+      provenance: provenance
+    }
+  end
+end


### PR DESCRIPTION
Closes #228

Characterization property tests over the tiers 1–2 decomposition pipeline: from `Cake.Decomposition.Result` through merged retrieval through `Cake.Responses.process/3` citations. Per the issue's expectation, **all four invariants pass on arrival** — the pipeline already upholds the traceability contract, so there are no fix commits, and this PR is test-only (no lib changes).

## What changed

- **`Cake.DecompositionGenerators`** (`test/support/`, mirroring the `Cake.QueryGenerators` pattern): generators for decomposed `Decomposition.Result` structs; `decomposed_retrieval/0`, which pairs a decomposition with per-sub-question `Search.Result` groups whose provenance is stamped to match (unit IDs drawn from a shared pool so cross-group duplicates exercise the merge's dedup); `plain_results/0` for the non-decomposed default-provenance path; and `response_text/0` producing LLM text with both valid and hallucinated `[N]` markers.
- **`decomposition_traceability_property_test.exs`** — the four invariants from the issue, harnessed deterministically: generated groups → `Conversation.merge_decomposed_results/1` → dense 1..N indexing (as the select stage does) → `Responses.process/3` with generated text.
  1. Every citation traces back to a `Search.Result` whose `Provenance.sub_question_index` is a valid key in the decomposition's `question_index` (plus `original_query` matches and the citation `id` matches the unit's `Citable` metadata).
  2. Every sub-question contributing ≥1 result to the merged context surfaces in the `chunk_map` — uncited sub-questions are not silently lost.
  3. No citation references a prompt index absent from the `chunk_map`; out-of-map markers surface as `:hallucinated_citation` warnings instead.
  4. Non-decomposed retrieval carries `decomposed: false` / nil-index provenance end to end, with citations still resolving.

## Judgment calls

- **Invariant 2 formalization.** The issue's wording ("union across all cited results covers every contributing sub-question") can't hold literally — the LLM text doesn't have to cite anything. The parenthetical states the real intent: orphaned sub-questions "surface in the provenance even if uncited." Formalized as: the set of `sub_question_index` values reachable from the `chunk_map` equals the set present in the merged context, which pins that `process/3` builds the chunk map total over the indexed context rather than only over cited entries.
- **Harness indexes the merged context directly** (dense 1..N), per the issue's harness spec ("run through `Responses.process/3`"). Routing through `Prompt.prepare_context/2` instead would entangle these invariants with the relevance floor, which is orthogonal to traceability.
- **`@moduletag capture_log: true`** — the hallucinated-marker generator makes `Citations.extract` log its expected warning hundreds of times per run; capture keeps suite output readable and ExUnit still prints logs for failing runs.

## Gates

`mix compile --force --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (baseline only), `mix docs --warnings-as-errors`, `mix test --exclude integration`: 82 properties, 603 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4BFgcRnvdsdTDmLovYe9m)_