### PR TITLE
Roadmap: professional rewrite, verified citations, status checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ After any task that changes architecture, module boundaries, conventions, or too
 3. Make approved edits before closing.
 4. Unsure whether a change warrants a doc update? Ask.
 
-**Enumeration rule:** if the README lists things (behaviours, protocols, structs, implementations, pipeline implementations) and you create a new instance of that kind, add it to the list.
+**Enumeration rule:** if the README lists things (behaviours, protocols, structs, implementations, pipeline implementations) and you create a new instance of that kind, add it to the list. Every new issue cut must include, as its **final checkbox**, a documentation update that applies this rule — in particular, adding any custom structs the work introduces to the README's struct inventory.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Raw data structs hold the original fetched content before it is parsed into a GD
 
 Current raw data structs:
 
-- **`Cake.Documents.Hexdocs.Hexdoc`** — stores the raw HTML content fetched from hex.pm tarballs. Intermediate storage between download and parsing into `ParsedDocument`.
+- **`Cake.Documents.Hexdocs.Hexdoc`** — stores raw Elixir source cloned from the elixir-lang/elixir repository. Intermediate storage between download and parsing into `ParsedDocument`.
 
 ### Retrievables (Searchable Units)
 
@@ -191,7 +191,7 @@ Every custom struct in Cake, its module, its purpose, and whether it defines a `
 | `ParsedBook` | `Cake.Books.ParsedBook` | Book-level metadata for book-like documents. GDS identity module for the Books GDS. |
 | `Chunk` | `Cake.Books.Chunk` | Atomic searchable text fragment within a book. Retrieval unit for the Books GDS. |
 | `ParsedDocument` | `Cake.Documents.ParsedDocument` | Programming documentation entry. Both GDS identity and retrieval unit for the Documents GDS. |
-| `Hexdoc` | `Cake.Documents.Hexdocs.Hexdoc` | Raw HTML content fetched from hex.pm. Intermediate storage (raw data struct). |
+| `Hexdoc` | `Cake.Documents.Hexdocs.Hexdoc` | Raw Elixir source cloned from the elixir-lang/elixir repository. Intermediate storage (raw data struct). |
 | `FailedIngest` | `Cake.FailedIngests.FailedIngest` | Persists item-level pipeline failures for retry via `sweep/5`. |
 | `User` | `Cake.Accounts.User` | Phoenix authentication user record. |
 | `UserToken` | `Cake.Accounts.UserToken` | Session and email confirmation tokens. |
@@ -204,12 +204,20 @@ Every custom struct in Cake, its module, its purpose, and whether it defines a `
 | `Search.Query` | `Cake.Search.Query` | Composable query builder. Fields: `index`, `size`, `must`, `should`, `filter`, `min_score`. |
 | `Search.Hit` | `Cake.Search.Hit` | Backend-agnostic search hit. Every backend maps its native hit type into this struct at the boundary. Fields: `id`, `score`, `source`. |
 | `Search.Result` | `Cake.Search.Result` | Normalized search result. Carries retrieval unit, backend score, CAKE-computed scores (cosine, relevance), hit provenance (search vs. expansion), search conditions, and prompt index. Single carrier of all retrieval metadata through the pipeline. |
-| `Search.Provenance` | `Cake.Search.Provenance` | Search conditions (type, query text, decomposition flag, embedding model) attached to each `Search.Result`. |
+| `Search.Provenance` | `Cake.Search.Provenance` | Search conditions attached to each `Search.Result`: search type, query text, decomposition traceability (`decomposed`, `original_query`, `sub_question_index`), and embedding model. |
 | `Responses.Result` | `Cake.Responses.Result` | Output struct from post-generation processing. Contains the formatted response, citations, and chunk map. |
-| `Conversation.State` | `Cake.Conversation.State` | Internal state for the `Conversation` GenServer: id, collaborator modules (embeddings, generation, responses, gds), message history, retrieved results, chunk map, citations, and the turn FSM state. |
+| `Conversation.State` | `Cake.Conversation.State` | Internal state for the `Conversation` GenServer: id, collaborator modules (embeddings, generation, responses, decomposition, gds), message history, retrieved results, chunk map, citations, and the turn FSM state. |
 | `Books.PageContent` | `Cake.Books.PageContent` | Elixir-side struct the Rust PDF NIF decodes into (via NifStruct): one page's extracted text and page number. |
 | `Books.PdfExtraction` | `Cake.Books.PdfExtraction` | Elixir-side struct the Rust PDF NIF decodes into: the full extraction result (pages, skipped pages, title). |
 | `Books.SkippedPage` | `Cake.Books.SkippedPage` | Elixir-side struct the Rust PDF NIF decodes into: a page that could not be extracted, with its page number. |
+| `Decomposition.Result` | `Cake.Decomposition.Result` | Outcome of decomposing a question: `original_question`, `strategy` (`:none` \| `:flat`), `sub_questions`, and `question_index` mapping positional index → sub-question text so `Search.Provenance` can reference sub-questions by index. |
+
+### Embedded Schemas (LiveView forms)
+
+| Struct | Module | Purpose |
+|---|---|---|
+| `QuestionForm` | `CakeWeb.ChatLive.QuestionForm` | Embedded schema validating the chat question and mode (`:auto`/`:manual`). |
+| `SelectionForm` | `CakeWeb.ChatLive.SelectionForm` | Embedded schema validating document selection as a non-empty subset of the offered candidate IDs. |
 
 ---
 

--- a/feature_roadmap.md
+++ b/feature_roadmap.md
@@ -78,9 +78,9 @@ Hybrid search, re-ranking, and query expansion should all be first-class pipelin
 
 **Relevant work**
 
-- Wang et al., 2024, *Searching for Best Practices in Retrieval-Augmented Generation* — a broad empirical study of RAG configurations (retrievers, chunking, re-ranking) finding that hybrid search combined with HyDE-style query rewriting is often the best accuracy/latency trade-off. For Cake, their recommended "hybrid + HyDE" recipe is a strong candidate for the default retrieval preset.
-- Zhang et al., 2025, *LevelRAG: Enhancing Retrieval-Augmented Generation with Multi-hop Logic Planning over Rewriting Augmented Searchers* — decomposes complex queries into atomic sub-queries routed across multiple retrievers, independent of retriever-specific optimisation. Aligns with a "structured retrieval" preset combining graph, dense, and re-ranking stages.
-- AWS OpenSearch hybrid retrieval guidance (2024) — demonstrates neural sparse + dense hybrids on OpenSearch, directly applicable to Cake's stack. Suggests shipping a standard OpenSearch hybrid retriever module with tunable weights and field boosts, plus configuration templates for common corpus shapes (documentation, code, FAQ-heavy knowledge bases).
+- Wang et al., 2024, [*Searching for Best Practices in Retrieval-Augmented Generation*](https://arxiv.org/abs/2407.01219) (EMNLP 2024) — a broad empirical study of RAG configurations (retrievers, chunking, re-ranking) finding that hybrid search combined with HyDE-style query rewriting is often the best accuracy/latency trade-off. For Cake, their recommended "hybrid + HyDE" recipe is a strong candidate for the default retrieval preset.
+- Zhang et al., 2025, [*LevelRAG: Enhancing Retrieval-Augmented Generation with Multi-hop Logic Planning over Rewriting Augmented Searchers*](https://arxiv.org/abs/2502.18139) — decomposes complex queries into atomic sub-queries routed across multiple retrievers, independent of retriever-specific optimisation. Aligns with a "structured retrieval" preset combining graph, dense, and re-ranking stages.
+- AWS, 2024, [*Integrate sparse and dense vectors to enhance knowledge retrieval in RAG using Amazon OpenSearch Service*](https://aws.amazon.com/blogs/big-data/integrate-sparse-and-dense-vectors-to-enhance-knowledge-retrieval-in-rag-using-amazon-opensearch-service) — demonstrates neural sparse + dense hybrids on OpenSearch, directly applicable to Cake's stack. Suggests shipping a standard OpenSearch hybrid retriever module with tunable weights and field boosts, plus configuration templates for common corpus shapes (documentation, code, FAQ-heavy knowledge bases).
 - Domain-specific hybrid QA studies (2024–2025) report that dense + BM25 hybrids significantly improve question answering in specialised domains.
 
 **Open questions**
@@ -112,8 +112,8 @@ Hybrid search, re-ranking, and query expansion should all be first-class pipelin
 
 **Relevant work**
 
-- Zhu et al., 2025, *KG²RAG* — combines semantic retrieval with knowledge-graph-guided organisation and cross-encoder re-ranking. Points toward graph-aware re-rankers as an advanced option for tenants with graph data.
-- *Beyond Retrieval: Ensembling Cross-Encoders and GPT* (2025) — ensembles cross-encoders with LLM re-rankers for biomedical QA. Motivates pluggable re-ranker backends in Cake ("lightweight cross-encoder", "LLM re-ranker", "ensemble"), configurable per tenant.
+- Zhu et al., 2025, [*Knowledge Graph-Guided Retrieval Augmented Generation* (KG²RAG)](https://arxiv.org/abs/2502.06864) (NAACL 2025) — combines semantic retrieval with knowledge-graph-guided organisation and cross-encoder re-ranking. Points toward graph-aware re-rankers as an advanced option for tenants with graph data.
+- Verma et al., 2025, [*Beyond Retrieval: Ensembling Cross-Encoders and GPT Rerankers with LLMs for Biomedical QA*](https://arxiv.org/abs/2507.05577) — ensembles cross-encoders with LLM re-rankers for biomedical QA. Motivates pluggable re-ranker backends in Cake ("lightweight cross-encoder", "LLM re-ranker", "ensemble"), configurable per tenant.
 - Industry analyses (Pinecone, Databricks, and others) consistently identify re-ranking as one of the simplest high-impact additions to a RAG stack.
 
 **Open questions**
@@ -145,14 +145,14 @@ Hybrid search, re-ranking, and query expansion should all be first-class pipelin
 
 **Relevant work**
 
-- Zhang et al., 2025, *LevelRAG* — treats query rewriting as a general planning layer decoupled from any single retriever. For Cake, this suggests a "retrieval planner" abstraction: one module performs query decomposition and expansion, then routes sub-queries across hybrid retrievers.
-- Pan et al., 2025, *LLM-QE* — LLM-based query expansion using a Gaussian-kernel semantic space to refine multiple expansion vectors for dense retrieval. A future research direction rather than an MVP feature; a simplified multi-embedding expansion mode could follow later.
-- Zhang et al., 2024, *Exploring Best Practices of Query Expansion with LLMs for IR* — systematic study showing that query expansion helps weaker retrievers most; strong dense models already perform some semantic expansion implicitly. For Cake, expansion should be optional and primarily valuable for tenants using cheaper embedding models.
+- Zhang et al., 2025, [*LevelRAG*](https://arxiv.org/abs/2502.18139) — treats query rewriting as a general planning layer decoupled from any single retriever. For Cake, this suggests a "retrieval planner" abstraction: one module performs query decomposition and expansion, then routes sub-queries across hybrid retrievers.
+- Pan et al., 2025, [*LLM-Based Query Expansion with Gaussian Kernel Semantic Enhancement for Dense Retrieval*](https://www.mdpi.com/2079-9292/14/9/1744) (Electronics 14(9)) — query expansion using a Gaussian-kernel semantic space to refine multiple expansion vectors for dense retrieval. A future research direction rather than an MVP feature; a simplified multi-embedding expansion mode could follow later.
+- Zhang et al., 2024, [*Exploring the Best Practices of Query Expansion with Large Language Models*](https://aclanthology.org/2024.findings-emnlp.103/) (Findings of EMNLP 2024) — systematic study showing that query expansion helps weaker retrievers most; strong dense models already perform some semantic expansion implicitly. For Cake, expansion should be optional and primarily valuable for tenants using cheaper embedding models.
 
 **Open questions**
 
 - Evaluate per tenant whether query expansion helps, using small offline tests.
-- Investigate retrieval-based expansion (Olivera, 2025), where expansions are themselves retrieved and re-scored.
+- Investigate retrieval-grounded expansion in the style of the [RFG framework](https://www.scitepress.org/Link.aspx?doi=10.5220/0013836900004000) (Vega Centeno Olivera et al., KDIR 2025), where expansions are grounded in feedback from an initial retrieval and re-scored.
 
 ---
 
@@ -190,9 +190,9 @@ Chunking determines how raw documents are divided into embedding units. Recent l
 
 **Relevant work**
 
-- Chroma, 2024, *Evaluating Chunking Strategies for Retrieval* — rigorous comparison of chunking strategies using recall, precision, and IoU-style metrics; semantic and metadata-aware chunkers outperform naive ones, with open-source tooling. Cake could productise a comparable chunking evaluation lab — something few frameworks offer.
-- Merola et al., 2025, *Evaluating Advanced Chunking Strategies for RAG* — compares late chunking with contextual retrieval; contextual retrieval preserves coherence at higher cost, late chunking is efficient but loses detail. Suggests a "contextual retrieval mode" as an advanced option for high-value tenants.
-- Multimodal chunking for PDFs (2025) — uses multimodal models to handle tables, figures, and cross-page structure. Relevant for enterprises with heavy reporting output.
+- Smith and Troynikov (Chroma), 2024, [*Evaluating Chunking Strategies for Retrieval*](https://research.trychroma.com/evaluating-chunking) — rigorous comparison of chunking strategies using recall, precision, and IoU-style metrics; semantic and metadata-aware chunkers outperform naive ones, with open-source tooling. Cake could productise a comparable chunking evaluation lab — something few frameworks offer.
+- Merola and Singh, 2025, [*Reconstructing Context: Evaluating Advanced Chunking Strategies for Retrieval-Augmented Generation*](https://arxiv.org/abs/2504.19754) — compares late chunking with contextual retrieval; contextual retrieval preserves coherence at higher cost, late chunking is efficient but loses detail. Suggests a "contextual retrieval mode" as an advanced option for high-value tenants.
+- Tripathi et al., 2025, [*Vision-Guided Chunking Is All You Need: Enhancing RAG with Multimodal Document Understanding*](https://arxiv.org/abs/2506.16035) — uses multimodal models to handle tables, figures, and cross-page structure. Relevant for enterprises with heavy reporting output.
 
 ### 2.2 Overlapping Windows
 
@@ -375,8 +375,8 @@ Rather than passing context to the LLM with a bare "answer this", augmented gene
 
 **Relevant work**
 
-- Zhang et al., 2025, *LevelRAG* — a high-level searcher coordinating multiple low-level searchers via query decomposition.
-- Verma et al., 2025, *PLAN-RAG: Planning-guided Retrieval Augmented Generation* — matches the plan-then-retrieve paradigm.
+- Zhang et al., 2025, [*LevelRAG*](https://arxiv.org/abs/2502.18139) — a high-level searcher coordinating multiple low-level searchers via query decomposition.
+- Verma et al., 2024, [*Plan\*RAG: Efficient Test-Time Planning for Retrieval Augmented Generation*](https://arxiv.org/abs/2410.20753) (originally circulated as *Plan×RAG: Planning-guided Retrieval Augmented Generation*) — matches the plan-then-retrieve paradigm.
 - Work on question decomposition with cross-encoder re-ranking further supports staged, planned retrieval.
 
 For Cake: make the retrieval plan an explicit data structure in the pipeline rather than hidden prompt text, and keep the pipeline modular enough to add a planner stage later. Eventually, advanced users could supply simple planners (in Elixir) that choose retrieval strategy by question type.
@@ -411,9 +411,9 @@ This area covers preventing and detecting hallucinations and unfaithful answers 
 
 **Relevant work**
 
-- FaithJudge and the Vectara hallucination leaderboards (2025) — benchmark RAG faithfulness via LLM-as-judge.
-- Wallat et al., 2025, *Correctness is Not Faithfulness in RAG* — demonstrates that a correct citation is insufficient; the citation must actually ground the answer.
-- MetaRAG (2025) — a metamorphic testing framework for hallucination detection in production RAG systems where gold labels are unavailable.
+- Tamber et al. (Vectara), 2025, [*Benchmarking LLM Faithfulness in RAG with Evolving Leaderboards*](https://arxiv.org/abs/2505.04847) (EMNLP 2025 Industry) — introduces the FaithJudge framework and [hallucination leaderboard](https://github.com/vectara/FaithJudge) for LLM-as-judge faithfulness evaluation.
+- Wallat et al., 2024, [*Correctness is not Faithfulness in RAG Attributions*](https://arxiv.org/abs/2412.18004) — demonstrates that a correct citation is insufficient; the citation must actually ground the answer.
+- Sok et al., 2025, [*MetaRAG: Metamorphic Testing for Hallucination Detection in RAG Systems*](https://arxiv.org/abs/2509.09360) — a metamorphic testing framework for hallucination detection in production RAG systems where gold labels are unavailable.
 
 For Cake: short term, a simple faithfulness scorer using LLM-as-judge over the retrieved context; longer term, metamorphic tests integrated into the evaluation suite.
 
@@ -439,8 +439,8 @@ For Cake: short term, a simple faithfulness scorer using LLM-as-judge over the r
 
 **Relevant work**
 
-- CiteFix (2025) — post-processing that improves citation accuracy at minimal cost.
-- RAGE and related work — citation metrics for evaluating and tuning RAG systems.
+- Maheshwari et al., 2025, [*CiteFix: Enhancing RAG Accuracy Through Post-Processing Citation Correction*](https://arxiv.org/abs/2504.15629) (ACL 2025 Industry) — post-processing that improves citation accuracy at minimal cost.
+- Penzkofer and Baumann, 2024, [*Evaluating and Fine-Tuning Retrieval-Augmented Language Models to Generate Text with Accurate Citations*](https://aclanthology.org/2024.konvens-main.6/) (KONVENS 2024; the RAGE toolkit) — citation precision/recall metrics for evaluating and tuning RAG systems.
 
 For Cake: make citations mandatory for factual QA modes; build a generic citation data model (`chunk_id`, `char_span`, `doc_url`); and let tenant UIs style citations as they see fit.
 
@@ -471,7 +471,7 @@ This area moves beyond treating documents as bags of words, exploiting schemas, 
 - Combine structured queries (SQL, filters) with text search.
 - Summarise structured outputs into LLM-friendly snippets.
 
-**Relevant work.** Cheerla et al., 2025, *Advancing RAG for Structured and Semi-Structured Data* — hybrid retrieval combining BM25, dense retrieval, and metadata-aware filtering over structured data. For Cake: define a schema ingestion interface so that, given a table or API, Cake can build metadata-aware filters and join structured results with text context.
+**Relevant work.** Cheerla, 2025, [*Advancing Retrieval-Augmented Generation for Structured Enterprise and Internal Data*](https://arxiv.org/abs/2507.12425) — hybrid retrieval combining BM25, dense retrieval, and metadata-aware filtering over structured data. For Cake: define a schema ingestion interface so that, given a table or API, Cake can build metadata-aware filters and join structured results with text context.
 
 ### 6.2 Graph-Augmented Retrieval
 
@@ -497,9 +497,9 @@ This area moves beyond treating documents as bags of words, exploiting schemas, 
 
 **Relevant work**
 
-- Zhu et al., 2025, *KG²RAG* — semantic retrieval, then knowledge-graph-guided expansion and organisation into paragraphs for RAG.
-- Liu et al., 2025, *GGR* — GNN-guided KG-RAG that preserves key reasoning paths.
-- GraphRAG and related enterprise deployments report substantial gains on cross-document reasoning.
+- Zhu et al., 2025, [*KG²RAG*](https://arxiv.org/abs/2502.06864) — semantic retrieval, then knowledge-graph-guided expansion and organisation into paragraphs for RAG.
+- Liu et al., 2025, [*Knowledge Graph Retrieval-Augmented Generation via GNN-Guided Prompting*](https://openreview.net/forum?id=R1NWMExESj) (GGR) — GNN-guided KG-RAG that preserves key reasoning paths.
+- Edge et al., 2024, [*From Local to Global: A Graph RAG Approach to Query-Focused Summarization*](https://arxiv.org/abs/2404.16130) (Microsoft GraphRAG) and related enterprise deployments report substantial gains on cross-document reasoning.
 
 For Cake: do not attempt full GraphRAG in v1. Instead, provide hooks for tenants who already have graphs, and offer a basic document-derived graph (entities, document IDs, links).
 
@@ -552,7 +552,7 @@ Multi-turn RAG requires tracking what has been said, what has been retrieved, an
 - Bound short-term memory: the last N turns plus a running summary.
 - Summarise older turns.
 
-**Relevant work.** Surveys of RAG-driven memory architectures (2025) and multi-turn benchmarks such as MTRAG evaluate multi-turn retrieval and reasoning directly. For Cake: provide a built-in conversation memory store and retrieval hook, separate from the main knowledge base, with tenant-tunable memory length and summarisation strategy.
+**Relevant work.** Surveys of memory architectures in LLM systems (e.g. Wu et al., 2025, [*From Human Memory to AI Memory*](https://arxiv.org/abs/2504.15965)) and multi-turn benchmarks such as [MTRAG](https://arxiv.org/abs/2501.03468) evaluate multi-turn retrieval and reasoning directly. For Cake: provide a built-in conversation memory store and retrieval hook, separate from the main knowledge base, with tenant-tunable memory length and summarisation strategy.
 
 ### 7.2 Long-Term Memory
 
@@ -593,7 +593,7 @@ Multi-turn RAG requires tracking what has been said, what has been retrieved, an
 - Use a small coreference resolver over recent turns.
 - Use retrieval over conversation memory to find the most recently discussed entity.
 
-**Relevant work.** Multi-turn benchmarks such as MTRAG (2025) centre on QA where context tracking is essential. For Cake: make reference resolution an explicit pipeline step that rewrites the raw user query into a fully de-referenced query.
+**Relevant work.** Multi-turn benchmarks such as [MTRAG](https://arxiv.org/abs/2501.03468) (Katsis et al., 2025) centre on QA where context tracking is essential. For Cake: make reference resolution an explicit pipeline step that rewrites the raw user query into a fully de-referenced query.
 
 ---
 
@@ -625,9 +625,9 @@ Evaluation cannot be an afterthought. Production RAG requires constant measureme
 
 **Relevant work**
 
-- Saad-Falcon et al., 2024, *ARES* — automated RAG evaluation using synthetic queries and LLM judges.
-- FRAMES (2024) — a unified dataset for evaluating factuality, retrieval, and reasoning in RAG.
-- Synthetic test collections for IR (2024) — fully synthetic IR benchmarks built with LLMs.
+- Saad-Falcon et al., 2024, [*ARES: An Automated Evaluation Framework for Retrieval-Augmented Generation Systems*](https://aclanthology.org/2024.naacl-long.20/) (NAACL 2024) — automated RAG evaluation using synthetic queries and LLM judges.
+- Krishna et al., 2024, [*Fact, Fetch, and Reason: A Unified Evaluation of Retrieval-Augmented Generation*](https://arxiv.org/abs/2409.12941) (the FRAMES benchmark) — a unified dataset for evaluating factuality, retrieval, and reasoning in RAG.
+- Rahmani et al., 2024, [*Synthetic Test Collections for Retrieval Evaluation*](https://arxiv.org/abs/2405.07767) (SIGIR 2024) — fully synthetic IR benchmarks built with LLMs.
 
 For Cake: build a synthetic evaluation kit — given a corpus, auto-generate 100–500 synthetic queries and answers, run them through different Cake pipelines, and report recall, precision, and faithfulness metrics.
 

--- a/feature_roadmap.md
+++ b/feature_roadmap.md
@@ -1,2338 +1,712 @@
-# Table of Contents
-- [1. Retrieval](#1-retrieval-because-naive-vector-search-is-mid)
+# Cake Feature Roadmap: RAG Enhancements
+
+This document surveys the RAG techniques most relevant to Cake's evolution, organised into eight capability areas. Each subsection describes the technique, its trade-offs, mitigations for the main risks, relevant recent work, and the direction it suggests for Cake. The closing [Recommendations](#recommendations) section distils the survey into concrete priorities.
+
+## Contents
+
+- [1. Retrieval](#1-retrieval)
   - [1.1 Hybrid Search](#11-hybrid-search)
-  - [1.2 Re-ranking Pipelines](#12-re-ranking)
+  - [1.2 Re-ranking Pipelines](#12-re-ranking-pipelines)
   - [1.3 Query Expansion](#13-query-expansion)
 - [2. Chunking](#2-chunking)
   - [2.1 Semantic Chunking](#21-semantic-chunking)
   - [2.2 Overlapping Windows](#22-overlapping-windows)
   - [2.3 Multi-Representation Chunks](#23-multi-representation-chunks)
 - [3. Context Assembly](#3-context-assembly)
-  - [3.1 Deduplication & Consolidation](#31-deduplication--consolidation)
+  - [3.1 Deduplication and Consolidation](#31-deduplication-and-consolidation)
   - [3.2 Section-Aware Assembly](#32-section-aware-assembly)
-  - [3.3 Role-Based Context Windows](#33-role-based-context-windows)
+  - [3.3 Role-Annotated Context](#33-role-annotated-context)
 - [4. Augmented Generation](#4-augmented-generation)
   - [4.1 Contextual Reasoning Chains](#41-contextual-reasoning-chains)
   - [4.2 Retrieval-Augmented Planning](#42-retrieval-augmented-planning)
-- [5. Guardrails & Faithfulness](#5-guardrails--faithfulness)
+- [5. Guardrails and Faithfulness](#5-guardrails-and-faithfulness)
   - [5.1 Faithfulness Checks](#51-faithfulness-checks)
   - [5.2 Citation Mode](#52-citation-mode)
-- [6. Domain/Structured Retrieval](#6-domainstructured-retrieval)
+- [6. Structured and Domain-Aware Retrieval](#6-structured-and-domain-aware-retrieval)
   - [6.1 Schema-Aware Retrieval](#61-schema-aware-retrieval)
   - [6.2 Graph-Augmented Retrieval](#62-graph-augmented-retrieval)
-  - [6.3 Logit Bias](#63-logit-bias)
+  - [6.3 Vocabulary Steering](#63-vocabulary-steering)
 - [7. Conversational Memory](#7-conversational-memory)
-  - [7.1 Short-Term Memory Embeddings](#71-short-term-memory-embeddings)
+  - [7.1 Conversation-Aware Retrieval](#71-conversation-aware-retrieval)
   - [7.2 Long-Term Memory](#72-long-term-memory)
   - [7.3 Multi-Turn Reference Disambiguation](#73-multi-turn-reference-disambiguation)
-- [8. Evaluation & Feedback](#8-evaluation--feedback-loops)
-  - [8.1 Synthetic Query Testing](#81-synthetic-queries-for-recall-testing)
-  - [8.2 Drift Detection](#82-drift-detection-for-content-updates)
-- [Cake Recommendations](#recommendations-for-cakeue)
-  - [A. Immediate Priorities](#a-immediate-priorities-next-mvp-iterations)
-  - [B. Changes to the MVP Design](#b-changes-to-the-mvp-design)
-  - [C. Most Relevant to Scaling Cake](#c-most-relevant-to-scaling-cakeue)
-  - [D. Competitive Advantages](#d-potential-competitive-advantages-to-seize-early)
-
-# RAG Enhancements
-
-## 1. Retrieval (because naive vector search is mid)
-[Back to table of contents](#table-of-contents)
-
-#### What this class is  
-This covers how you *select candidate chunks* from the corpus before the LLM sees anything. If retrieval sucks, nothing downstream fixes it. Hybrid search, re-ranking, and query expansion are three levers to boost recall *and* precision beyond “cosine similarity on a single embedding.”
-
-In real RAG systems, retrieval is often 70–80% of the quality story. :contentReference[oaicite:0]{index=0}
-
-#### Relevance to Cake  
-Cake is meant to be a **framework**, not just a toy app. That means your retrieval layer has to be:
-- **Configurable** (per-tenant / per-domain retrieval recipes)  
-- **Composable** (query → retrieve → re-rank → post-filter)  
-- **Observable** (you can see *why* a query failed)  
-
-Hybrid, reranking, and query expansion should be **first-class pipeline stages** Cake exposes.
+- [8. Evaluation and Feedback Loops](#8-evaluation-and-feedback-loops)
+  - [8.1 Synthetic Query Evaluation](#81-synthetic-query-evaluation)
+  - [8.2 Drift Detection](#82-drift-detection)
+- [Recommendations](#recommendations)
+  - [A. Immediate Priorities](#a-immediate-priorities)
+  - [B. MVP Design Changes](#b-mvp-design-changes)
+  - [C. Scaling Considerations](#c-scaling-considerations)
+  - [D. Early Differentiators](#d-early-differentiators)
+  - [Risks](#risks)
 
 ---
 
-#### 1.1 Hybrid Search  
-**What it is**  
-Combine **sparse** (BM25 / neural sparse) and **dense** (embeddings) retrieval into one ranked list. Either via score fusion (e.g., weighted sum) or multi-stage (BM25 → dense filter or vice-versa). :contentReference[oaicite:1]{index=1}  
+## 1. Retrieval
 
-**Pros**  
-- Much better robustness on:  
-  - rare terms, IDs, codes (sparse)  
-  - paraphrases and fuzzy language (dense)  
-- Works well on **enterprise KBs** that mix jargon with natural language.  
-- Plays nicely with OpenSearch (you already get BM25 + dense + neural sparse).  
+Retrieval determines which candidate chunks are selected from the corpus before the LLM sees anything. Weak retrieval cannot be compensated for downstream; in production RAG systems it typically accounts for the majority of answer quality. Hybrid search, re-ranking, and query expansion are three levers for improving recall and precision beyond cosine similarity on a single embedding.
 
-**Cons**  
-- Score fusion is fiddly (how to weight sparse vs dense).  
-- Latency and infra complexity (multiple retrievers).  
-- Can over-emphasize long docs or spammy fields if BM25 isn’t tuned.  
+**Relevance to Cake.** Cake is a framework, not a single application, so the retrieval layer must be:
 
-**Mitigations**  
-- Learn weights per index or per tenant (simple grid search or small regression model).  
-- Normalize scores (z-score or min–max per retriever).  
-- Use **metadata filters** and field-specific boosts to keep BM25 sane (e.g., title > body).  
+- **Configurable** — per-tenant and per-domain retrieval recipes.
+- **Composable** — query → retrieve → re-rank → post-filter.
+- **Observable** — it should be possible to see why a given query failed.
 
-**Recent work & Cake angle**  
-- [Wang et al., 2024] *“Searching for Best Practices in Retrieval-Augmented Generation”* – looks at combinations of retrieval strategies. :contentReference[oaicite:2]{index=2}  
-  - *Goal*: Benchmark many RAG configs (retrievers, chunking, reranking)  
-  - *Practicality*: Very high (off-the-shelf setups)  
-  - *Future*: More adaptive hybrids (e.g., dynamic weighting per query)  
-  - *For Cake*: Treat their recommended “Hybrid + HyDE” recipe as a **default retrieval preset**.  
-- [Zhang et al., 2025] *“LevelRAG: Enhancing Retrieval-Augmented Generation with Multi-hop Logic Planning over Rewriting Augmented Searchers”* – hybrid + multi-searchers. :contentReference[oaicite:3]{index=3}  
-  - *Goal*: Decompose complex queries into atomic subqueries, independent of retriever-specific optimization.  
-  - *Practicality*: Moderate-high for enterprises that have graphs or can derive them.  
-  - *For Cake*: Aligns strongly with a **“structured retrieval preset”**: graph + dense + rerank.  
+Hybrid search, re-ranking, and query expansion should all be first-class pipeline stages that Cake exposes.
 
-**Independent research ideas**  
-- Learn **per-tenant fusion weights** from minimal feedback (clicks / thumbs up/down).  
-- Evaluate whether **OpenSearch neural sparse + dense** beats classic BM25 + dense for the specific enterprise domains you target, and publish that as a “Cake Retrieval Study”.
+### 1.1 Hybrid Search
 
----
+**What it is.** Combine sparse retrieval (BM25 or neural sparse) with dense (embedding-based) retrieval into one ranked list, either via score fusion (e.g. a weighted sum) or a multi-stage arrangement (BM25 followed by a dense filter, or vice versa). Hybrid retrieval is now widely regarded as the best default for RAG.
 
-#### 1.2 Re-ranking Pipelines  
-**What it is**  
-Two-stage retrieval: first get a big candidate pool (e.g. top-50 or top-100 chunks), then score each candidate more precisely with a **cross encoder** or LLM-as-reranker, producing a much better top-5.
+**Benefits**
 
-**Pros**  
-- Huge quality bump, especially in noisy KBs (duplicate docs, irrelevant boilerplate).  
-- You can keep recall high while controlling **LLM context size**.  
-- Great in high-stakes domains (compliance, finance, medical).  
+- Substantially more robust across query types: sparse handles rare terms, identifiers, and codes; dense handles paraphrase and fuzzy language.
+- Well suited to enterprise knowledge bases that mix jargon with natural language.
+- Maps directly onto OpenSearch, which provides BM25, dense, and neural sparse retrieval out of the box.
 
-**Cons**  
-- Extra latency (heavy model scoring 50–100 candidates).  
-- Additional infra complexity (GPU/CPU serving, batching, caching).  
-- If your baseline retrieval is garbage, reranking can’t fix it.  
+**Trade-offs**
 
-**Mitigations**  
-- Use efficient cross encoders (e.g., MiniLM, MPNet) and **batch across tenants**.  
-- Cache reranker scores for repeated queries or canonical question templates.  
-- Use **adaptive candidate set sizes** (k=30 for short queries, k=100 for multi-hop).  
+- Score fusion is sensitive to how sparse and dense scores are weighted.
+- Multiple retrievers add latency and infrastructure complexity.
+- Untuned BM25 can over-emphasise long documents or noisy fields.
 
-**Recent work & Cake angle**  
-- [Zhu et al., 2025] *KG²RAG* – semantic retrieval + KG-guided organization + reranking; uses cross-encoders.  
-  - *Goal*: Improve coherence and relevance by using KG structure plus reranking.  
-  - *For Cake*: Enables “graph-aware rerankers” as an advanced option.  
-- Industry write-ups (Pinecone, Databricks, blogs) show reranking as one of the simplest big wins.
+**Mitigations**
 
-**Independent research ideas**  
-- Re-rank **not just chunks but chunk-groups** (e.g., all chunks from the same doc or section).  
-- Use **multi-objective reranking** for enterprise: relevance + recency + access control.
+- Learn fusion weights per index or per tenant (grid search or a small regression model suffices).
+- Normalise scores per retriever (z-score or min–max).
+- Use metadata filters and field-specific boosts (e.g. title over body) to keep BM25 well behaved.
 
----
+**Relevant work**
 
-#### 1.3 Query Expansion  
-**What it is**  
-Automatically expand or rewrite a user query into richer representations: paraphrases, related terms, or synthetic “ideal answers” whose content you then retrieve against. Includes HyDE-style (“generate a hypothetical answer, embed that”) and LLM-based query expansion variants.
+- Wang et al., 2024, *Searching for Best Practices in Retrieval-Augmented Generation* — a broad empirical study of RAG configurations (retrievers, chunking, re-ranking) finding that hybrid search combined with HyDE-style query rewriting is often the best accuracy/latency trade-off. For Cake, their recommended "hybrid + HyDE" recipe is a strong candidate for the default retrieval preset.
+- Zhang et al., 2025, *LevelRAG: Enhancing Retrieval-Augmented Generation with Multi-hop Logic Planning over Rewriting Augmented Searchers* — decomposes complex queries into atomic sub-queries routed across multiple retrievers, independent of retriever-specific optimisation. Aligns with a "structured retrieval" preset combining graph, dense, and re-ranking stages.
+- AWS OpenSearch hybrid retrieval guidance (2024) — demonstrates neural sparse + dense hybrids on OpenSearch, directly applicable to Cake's stack. Suggests shipping a standard OpenSearch hybrid retriever module with tunable weights and field boosts, plus configuration templates for common corpus shapes (documentation, code, FAQ-heavy knowledge bases).
+- Domain-specific hybrid QA studies (2024–2025) report that dense + BM25 hybrids significantly improve question answering in specialised domains.
 
-**Pros**  
-- Fixes short or vague queries (“VPN broken”, “hr policy maternity”).  
-- Bridges lexical gaps (synonyms, abbreviations, multilingual).  
-- Especially strong when combined with hybrid retrieval.  
+**Open questions**
 
-**Cons**  
-- Can introduce **drift** if expansions hallucinate irrelevant concepts.  
-- High compute if you generate many expansions per query.  
-- Can hurt precision by pulling in tangential docs.  
+- Learn per-tenant fusion weights from minimal feedback signals (clicks, explicit ratings).
+- Evaluate whether OpenSearch neural sparse + dense outperforms classic BM25 + dense for Cake's target enterprise domains, and publish the results as a retrieval study.
 
-**Mitigations**  
-- Limit to **2–3 expansions** and keep them short.  
-- Use **retrieval feedback**: discard expansions whose retrieved set has low similarity to others.  
-- Add a “no expansion” path and AB compare.  
+### 1.2 Re-ranking Pipelines
 
-**Recent work & Cake angle**  
-- [Zhang et al., 2025] *LevelRAG* – query rewriting decoupled from any single retriever. :contentReference[oaicite:4]{index=4}  
-  - *Goal*: Make query rewriting a general planning layer, not hard-tied to dense retrievers.  
-  - *For Cake*: Use as your **“retrieval planner”** abstraction: one module does query decomposition/expansion, and then routes sub-queries across hybrid retrievers.  
-- [Zhang et al., 2024] *“Exploring Best Practices of Query Expansion with LLMs for IR”* – systematic study of LLM-based query expansion. :contentReference[oaicite:5]{index=5}  
-  - *Takeaway*: QE helps *weaker* retrievers more; strong dense models already do some semantic expansion.  
-  - *For Cake*: Make QE **optional** and mostly useful when tenants use cheaper embeddings.  
+**What it is.** Two-stage retrieval: first gather a large candidate pool (top-50 to top-100 chunks), then score each candidate more precisely with a cross-encoder or an LLM acting as re-ranker, producing a much stronger top-5.
 
-**Independent research ideas**  
-- Evaluate **per-tenant** whether QE helps (small offline tests).  
-- Try **RAG-based QE** (as in Olivera 2025) where expansions are themselves retrieved and re-scored.
+**Benefits**
+
+- Large quality improvement, especially in noisy knowledge bases with duplicate documents and boilerplate.
+- Keeps recall high while controlling the LLM context size.
+- Valuable in high-stakes domains (compliance, finance, medical).
+
+**Trade-offs**
+
+- Added latency from scoring 50–100 candidates with a heavier model.
+- Additional serving infrastructure (GPU/CPU capacity, batching, caching).
+- Re-ranking cannot compensate for poor first-stage retrieval.
+
+**Mitigations**
+
+- Use efficient cross-encoders (e.g. MiniLM, MPNet) and batch requests across tenants.
+- Cache re-ranker scores for repeated queries and canonical question templates.
+- Adapt candidate pool size to the query (e.g. k=30 for short queries, k=100 for multi-hop).
+
+**Relevant work**
+
+- Zhu et al., 2025, *KG²RAG* — combines semantic retrieval with knowledge-graph-guided organisation and cross-encoder re-ranking. Points toward graph-aware re-rankers as an advanced option for tenants with graph data.
+- *Beyond Retrieval: Ensembling Cross-Encoders and GPT* (2025) — ensembles cross-encoders with LLM re-rankers for biomedical QA. Motivates pluggable re-ranker backends in Cake ("lightweight cross-encoder", "LLM re-ranker", "ensemble"), configurable per tenant.
+- Industry analyses (Pinecone, Databricks, and others) consistently identify re-ranking as one of the simplest high-impact additions to a RAG stack.
+
+**Open questions**
+
+- Re-rank chunk *groups* (all chunks from the same document or section) rather than individual chunks.
+- Multi-objective re-ranking for enterprise use: relevance combined with recency and access control.
+
+### 1.3 Query Expansion
+
+**What it is.** Automatically expand or rewrite a user query into richer representations: paraphrases, related terms, or synthetic "ideal answers" that are then used for retrieval. Includes HyDE-style approaches (generate a hypothetical answer and embed it) and LLM-based expansion variants.
+
+**Benefits**
+
+- Compensates for short or vague queries ("VPN broken", "hr policy maternity").
+- Bridges lexical gaps: synonyms, abbreviations, multilingual phrasing.
+- Particularly effective in combination with hybrid retrieval.
+
+**Trade-offs**
+
+- Expansions can drift, introducing irrelevant concepts.
+- Generating many expansions per query is computationally expensive.
+- Can reduce precision by pulling in tangential documents.
+
+**Mitigations**
+
+- Limit expansion to two or three short variants.
+- Use retrieval feedback: discard expansions whose retrieved sets diverge from the others.
+- Keep a no-expansion path and A/B compare against it.
+
+**Relevant work**
+
+- Zhang et al., 2025, *LevelRAG* — treats query rewriting as a general planning layer decoupled from any single retriever. For Cake, this suggests a "retrieval planner" abstraction: one module performs query decomposition and expansion, then routes sub-queries across hybrid retrievers.
+- Pan et al., 2025, *LLM-QE* — LLM-based query expansion using a Gaussian-kernel semantic space to refine multiple expansion vectors for dense retrieval. A future research direction rather than an MVP feature; a simplified multi-embedding expansion mode could follow later.
+- Zhang et al., 2024, *Exploring Best Practices of Query Expansion with LLMs for IR* — systematic study showing that query expansion helps weaker retrievers most; strong dense models already perform some semantic expansion implicitly. For Cake, expansion should be optional and primarily valuable for tenants using cheaper embedding models.
+
+**Open questions**
+
+- Evaluate per tenant whether query expansion helps, using small offline tests.
+- Investigate retrieval-based expansion (Olivera, 2025), where expansions are themselves retrieved and re-scored.
 
 ---
 
 ## 2. Chunking
-[Back to table of contents](#table-of-contents)
 
-#### What this class is  
-Chunking is how you cut raw docs into embedding units. The literature is loud now: **chunking strategy can easily swing recall by ~5–10 percentage points** for real RAG tasks.
+Chunking determines how raw documents are divided into embedding units. Recent literature indicates that chunking strategy alone can move recall by five to ten percentage points on realistic RAG tasks.
 
-#### Relevance to Cake  
-Cake as a framework should treat **chunkers as pluggable strategies** with:
-- Defaults (recursive char, semantic, metadata-aware)  
-- Domain-specific presets (PDF reports vs tickets vs code)  
-- Evaluation harnesses (so tenants can *see* how chunking changes retrieval)
+**Relevance to Cake.** As a framework, Cake should treat chunkers as pluggable strategies with:
 
----
+- Sensible defaults (recursive character, semantic, metadata-aware).
+- Domain-specific presets (PDF reports vs. tickets vs. code).
+- Evaluation harnesses, so tenants can measure how chunking changes retrieval.
 
-#### 2.1 Semantic Chunking  
-**What it is**  
-Use document structure and semantics (headings, paragraphs, list boundaries, LLM segmenters) instead of dumb “every 512 chars.”
+### 2.1 Semantic Chunking
 
-**Pros**  
-- Higher chance that a chunk is **self-contained enough** to answer a question.  
-- Fewer “cut in the middle of a concept” issues.  
-- Better for long enterprise docs (policies, SOPs, contracts).
+**What it is.** Segment documents using structure and semantics — headings, paragraphs, list boundaries, or LLM-based segmenters — rather than fixed-size windows.
 
-**Cons**  
-- More complex ingestion (you need robust parsing).  
-- PDF/HTML soup can break structural cues.  
-- Latency/cost if you use an LLM for segmentation.  
+**Benefits**
 
-**Mitigations**  
-- Use **cheap deterministic rules** first (headings, sections) and only fallback to LLM chunking for ugly docs.  
-- Cache multimodal chunk results aggressively.  
-- Log “chunk usefulness” over time and refine heuristics.
+- Chunks are more likely to be self-contained enough to answer a question.
+- Fewer concepts cut mid-thought at chunk boundaries.
+- Better suited to long enterprise documents (policies, SOPs, contracts).
 
-**Recent work & Cake angle**  
-- *Chroma “Evaluating Chunking Strategies for Retrieval” (2024)* – rigorous analysis of chunking strategies using Recall, Precision, IoU-style metrics.  
-  - *For Cake*: Build a **chunking-eval lab** similar to Chroma’s.  
-- *“Evaluating Advanced Chunking Strategies for RAG” (Merola et al., 2025)* – compares late chunking vs contextual retrieval.  
-  - *For Cake*: Suggest a **“contextual retrieval mode”** as advanced option.  
-- *Multimodal chunking for PDFs (2025)* – uses LLMs/vision to handle tables, figures.  
-  - *Future*: Important for enterprises with heavy reporting.
+**Trade-offs**
 
----
+- Requires more sophisticated ingestion and robust parsing.
+- Poorly structured PDF/HTML can defeat structural cues.
+- LLM-based segmentation adds latency and cost.
 
-#### 2.2 Overlapping Windows  
-**What it is**  
-Allow chunks to overlap so that boundary regions appear in multiple chunks (e.g., 1k tokens with 200-token overlap).
+**Mitigations**
 
-**Pros**  
-- Reduces “I cut out the crucial sentence” errors.  
-- Essential for code, protocols, step-wise procedures.  
-- Makes retrieval more tolerant to segmentation choices.
+- Apply inexpensive deterministic rules first (headings, sections); fall back to LLM chunking only for unstructured documents.
+- Cache LLM and multimodal chunking results aggressively.
+- Track chunk usefulness over time and refine heuristics accordingly.
 
-**Cons**  
-- Increases index size and ingest cost.  
-- Can amplify duplicates leading to retrieval redundancy.  
-- More noise if reranker/generator isn’t smart.
+**Relevant work**
 
-**Mitigations**  
-- Tune overlap per doc type (large for code, small for FAQs).  
-- Combine with **deduplication** in retrieval (merge overlapping hits).  
-- Use chunk grouping at context-assembly time.
+- Chroma, 2024, *Evaluating Chunking Strategies for Retrieval* — rigorous comparison of chunking strategies using recall, precision, and IoU-style metrics; semantic and metadata-aware chunkers outperform naive ones, with open-source tooling. Cake could productise a comparable chunking evaluation lab — something few frameworks offer.
+- Merola et al., 2025, *Evaluating Advanced Chunking Strategies for RAG* — compares late chunking with contextual retrieval; contextual retrieval preserves coherence at higher cost, late chunking is efficient but loses detail. Suggests a "contextual retrieval mode" as an advanced option for high-value tenants.
+- Multimodal chunking for PDFs (2025) — uses multimodal models to handle tables, figures, and cross-page structure. Relevant for enterprises with heavy reporting output.
 
-**Recent work & Cake angle**  
-Most recent chunking studies treat overlap as a tunable hyperparameter and show moderate overlap (10-30%) is generally beneficial.  
-For Cake:  
-- Allow **per-index overlap configuration**.  
-- Provide “profiles” like: “Long-form policy docs” (moderate overlap) and “Code/API docs” (higher overlap).
+### 2.2 Overlapping Windows
 
----
+**What it is.** Allow adjacent chunks to overlap so boundary regions appear in multiple chunks (e.g. 1,000-token chunks with 200-token overlap).
 
-#### 2.3 Multi-Representation Chunks  
-**What it is**  
-Store **multiple embeddings per chunk**, each capturing a different aspect: raw text, summary, entities, maybe separate embeddings for title vs body. Sometimes called **multi-vector embeddings**.
+**Benefits**
 
-**Pros**  
-- Better retrieval for:  
-  - Entity-heavy queries (use NER embedding)  
-  - Conceptual queries (use summary embedding)  
-- Allows you to weight different views at query time.
+- Reduces errors caused by a crucial sentence falling on a chunk boundary.
+- Important for code, protocols, and step-wise procedures.
+- Makes retrieval more tolerant of segmentation choices.
 
-**Cons**  
-- More storage.  
-- More complex retrieval logic.  
-- Index maintenance is harder (multiple fields per chunk).
+**Trade-offs**
 
-**Mitigations**  
-- Start with just **two representations**: full chunk and summary/entities.  
-- Use OpenSearch’s support for multiple vector fields per document.  
-- Use **simple fusion rules** per query type.
+- Increases index size and ingestion cost.
+- Amplifies duplicates, adding retrieval redundancy.
+- More noise for downstream stages if the re-ranker or generator cannot filter it.
 
-**Recent work & Cake angle**  
-- Industry write-ups (Baobab, AI Edge, vector DB blogs) show multi-vector yielding significant improvements.  
-  - *For Cake*: This is a **killer differentiator**: offer a **multi-representation schema** as part of the ingestion config and let advanced users plug in their own summarizers/NERs.  
-- Independent research:  
-  - Perform studies on **which combos of representations** give best returns for enterprise KBs (e.g., title + summary vs summary + entities).  
-  - Build a small paper: “Multi-Representation Chunking for Enterprise RAG with OpenSearch”.
+**Mitigations**
+
+- Tune overlap per document type: larger for code, smaller for FAQs.
+- Pair with deduplication at retrieval time, merging overlapping hits.
+- Group related chunks during context assembly.
+
+**Relevant work.** Recent chunking studies treat overlap as a tunable hyperparameter and find moderate overlap (10–30%) generally beneficial, with diminishing returns beyond that. For Cake: support per-index overlap configuration and ship profiles such as "long-form policy documents" (moderate overlap) and "code/API documentation" (higher overlap).
+
+### 2.3 Multi-Representation Chunks
+
+**What it is.** Store multiple embeddings per chunk, each capturing a different view: raw text, summary, extracted entities, or separate title and body embeddings. Also known as multi-vector embeddings.
+
+**Benefits**
+
+- Improves retrieval for entity-heavy queries (entity embedding) and conceptual queries (summary embedding).
+- Different views can be weighted at query time.
+
+**Trade-offs**
+
+- Higher storage requirements.
+- More complex retrieval logic.
+- Harder index maintenance, with multiple vector fields per chunk.
+
+**Mitigations**
+
+- Start with two representations: the full chunk plus a summary or entity view.
+- Use OpenSearch's support for multiple vector fields per document.
+- Apply simple fusion rules per query type.
+
+**Relevant work.** Industry reports show multi-vector retrieval yielding significant improvements on heterogeneous data, and RAG evolution reviews note that token-level and multi-vector representations are increasingly common for complex document structures. For Cake this is a genuine differentiator: offer a multi-representation schema as part of the ingestion configuration and let advanced users plug in their own summarisers and entity extractors.
+
+**Open questions**
+
+- Which combinations of representations give the best returns for enterprise knowledge bases (e.g. title + summary vs. summary + entities)?
+- The results could support a short publication: *Multi-Representation Chunking for Enterprise RAG with OpenSearch*.
 
 ---
 
 ## 3. Context Assembly
-[Back to table of contents](#table-of-contents)
 
-#### What this class is  
-You’ve got a set of retrieved chunks. Now you decide **what to send to the LLM** and **how**. Context assembly is about:  
-- Removing duplicates  
-- Grouping related chunks  
-- Annotating their roles  
-This is hugely impactful for **hallucinations and coherence**, especially on long contexts.
+Given a set of retrieved chunks, context assembly decides what is sent to the LLM and in what form: removing duplicates, grouping related chunks, and annotating their roles. This stage has a large effect on hallucination rates and coherence, particularly with long contexts.
 
-#### Relevance to Cake  
-Most frameworks treat this as an afterthought. You can make it a **first-class pipeline stage**:  
-- A “context builder” that’s pluggable per tenant.  
-- Built-in strategies: simple top-k, grouped by document, grouped by section/role, etc.
+**Relevance to Cake.** Most frameworks treat context assembly as an afterthought. Cake can make it a first-class pipeline stage: a context builder that is pluggable per tenant, with built-in strategies ranging from simple top-k through grouping by document, section, or role.
 
----
+### 3.1 Deduplication and Consolidation
 
-#### 3.1 Deduplication and Consolidation  
-**What it is**  
-- **Deduplication**: removing near-identical chunks (same text, or high cosine sim).  
-- **Consolidation**: merging multiple related chunks into concise summaries *before* sending to the LLM.
+**What it is.** *Deduplication* removes near-identical chunks (identical text or high cosine similarity). *Consolidation* merges related chunks into concise summaries before they reach the LLM.
 
-**Pros**  
-- Less wasted context budget.  
-- Reduces conflicting statements.  
-- Makes answers more grounded and concise.
+**Benefits**
 
-**Cons**  
-- Summarization can itself hallucinate or drop critical detail.  
-- Extra latency for consolidation step.  
-- Requires careful citation tracking.
+- Less wasted context budget.
+- Fewer conflicting statements in context.
+- More grounded, concise answers.
 
-**Mitigations**  
-- Use **extractive summaries** where possible (pull key sentences instead of abstractive).  
-- Limit consolidation to chunks from the same doc/section.  
-- Keep links back to all source chunk IDs for citations.
+**Trade-offs**
 
-**Recent work & Cake angle**  
-Most RAG best-practice guides emphasize that naive “dump top N chunks as-is” is suboptimal.  
-For Cake:  
-- Implement a **document-level context builder**: retrieve chunks → cluster by doc → summarise per doc.  
-- Add a “strict mode” where only exact chunks (no summarisation) are used for high-risk queries.
+- Summarisation can itself hallucinate or drop critical detail.
+- Consolidation adds latency.
+- Citation tracking becomes more involved.
 
----
+**Mitigations**
 
-#### 3.2 Section-aware Assembly  
-**What it is**  
-Group chunks by document sections (e.g., “Section 3: Billing Disputes”) or conceptual “sections” (background, constraints, examples), and feed this structured context to the LLM.
+- Prefer extractive summaries (selecting key sentences) over abstractive rewrites.
+- Restrict consolidation to chunks from the same document or section.
+- Retain links to all source chunk IDs for citation purposes.
 
-**Pros**  
-- Reduces context confusion by giving the model **labeled buckets**.  
-- Works well for multi-doc answers (“Policy A says X, Policy B says Y”).  
-- Helps multi-hop reasoning—model sees which chunk is doing what.
+**Relevant work.** RAG best-practice guides consistently note that passing the top-N chunks verbatim is suboptimal; several employ post-retrieval clustering plus summarisation. For Cake: implement a document-level context builder (retrieve → cluster by document → summarise per document), and add a strict mode that uses only exact, unconsolidated chunks for high-risk queries.
 
-**Cons**  
-- Requires good metadata at ingest (parse headings/hierarchy).  
-- Not all corpora have clean structure (ticket logs, chat).  
-- Prompts get more complex.
+### 3.2 Section-Aware Assembly
 
-**Mitigations**  
-- For unstructured data, use simple heuristics (source, date, doc type) as pseudo-sections.  
-- Build default prompt scaffolds (“You are given multiple sections: …”).
+**What it is.** Group chunks by document section (e.g. "Section 3: Billing Disputes") or by conceptual role (background, constraints, examples), and present that structure to the LLM.
 
-**Recent work & Cake angle**  
-OpenAI community posts and enterprise guides show sectioned context improves RAG QA quality.  
-For Cake:  
-- Include a **section-aware context template** as a core feature.  
-- Expose structured prompts where you pass context as `{definitions:[], procedures:[], examples:[]}`.
+**Benefits**
 
----
+- Labelled groupings reduce context confusion.
+- Effective for multi-document answers ("Policy A says X; Policy B says Y").
+- Supports multi-hop reasoning by making each chunk's role explicit.
 
-#### 3.3 Context Windows with Roles  
-**What it is**  
-Assign roles to chunks: **facts**, **definitions**, **constraints**, **examples**, **user history**, etc., and instruct the LLM how to use them (e.g., “prioritise constraints over examples when conflicts occur”).
+**Trade-offs**
 
-**Pros**  
-- Makes answers more deterministic and policy-compliant.  
-- Lets you handle conflicts (policy vs example) more predictably.  
-- Good fit for enterprise compliance / SOP flows.
+- Depends on good metadata at ingestion (headings, hierarchy).
+- Not all corpora have clean structure (ticket logs, chat transcripts).
+- Prompt construction becomes more complex.
 
-**Cons**  
-- Requires classification of chunks (manual or model-based).  
-- More complicated prompts and context-building.
+**Mitigations**
 
-**Mitigations**  
-- Start with **simple roles** based on metadata or heuristics (title, path).  
-- Add optional **LLM-based role classification** as offline pipeline.
+- For unstructured data, use simple heuristics (source, date, document type) as pseudo-sections.
+- Provide default prompt scaffolds for sectioned context.
 
-**Recent work & Cake angle**  
-Less specific dedicated research, more an emerging pattern in enterprise RAG whitepapers (auditability, compliance).  
-For Cake:  
-- Make “role tagging” an optional ingest pipeline stage.  
-- At minimum: distinguish between **source docs**, **retrieval logs**, **conversation memory**.
+**Relevant work.** Community and enterprise guidance shows that sectioned context improves RAG QA quality. For Cake: include a section-aware context template as a core feature, and expose structured prompts where context is passed as, for example, `{definitions: [], procedures: [], examples: []}`.
+
+### 3.3 Role-Annotated Context
+
+**What it is.** Assign roles to chunks — facts, definitions, constraints, examples, user history — and instruct the LLM how to use them (e.g. "prioritise constraints over examples when they conflict").
+
+**Benefits**
+
+- More deterministic, policy-compliant answers.
+- Predictable conflict handling (policy vs. example).
+- A good fit for enterprise compliance and SOP workflows.
+
+**Trade-offs**
+
+- Requires chunk classification, whether manual or model-based.
+- More complex prompts and context construction.
+
+**Mitigations**
+
+- Start with simple roles derived from metadata or heuristics (title, path).
+- Add optional LLM-based role classification as an offline pipeline.
+
+**Relevant work.** Role-annotated context is an emerging pattern in enterprise RAG literature, motivated by auditability and consistency, rather than the subject of dedicated academic study. For Cake: make role tagging an optional ingestion stage, and at minimum always distinguish source documents, retrieval logs, and conversation memory.
 
 ---
 
-## 4. Augmented Generation, not Raw Generation
-[Back to table of contents](#table-of-contents)
+## 4. Augmented Generation
 
-#### What this class is  
-Instead of “throw context at LLM and say ‘answer this’”, you structure the **reasoning process**:
-- Retrieve → reason over evidence → then answer.
-- Sometimes with explicit intermediate steps (plans, chains, scratch-pads).  
-This reduces hallucinations and makes explanations more grounded.
+Rather than passing context to the LLM with a bare "answer this", augmented generation structures the reasoning process: retrieve, reason over the evidence, then answer — sometimes with explicit intermediate artifacts (plans, chains, scratchpads). This reduces hallucination and produces better-grounded explanations.
 
-#### Relevance to Cake  
-You want Cake to be more than “LangChain in Elixir.” Generation pipeline templates are a key differentiator:
-- “Strict QA”
-- “Summarise across docs”
-- “Decision memo”
+**Relevance to Cake.** For Cake to be more than "LangChain in Elixir", generation pipeline templates are a key differentiator — "strict QA", "summarise across documents", "decision memo" — each a procedural template for reasoning, not merely a prompt.
 
-All of them should be **procedural templates** for reasoning, not just prompts.
+### 4.1 Contextual Reasoning Chains
 
----
+**What it is.** The LLM explicitly generates intermediate reasoning steps over the retrieved evidence: extract key facts from each chunk, combine and reconcile them, then produce a final answer with citations.
 
-#### 4.1 Contextual Reasoning Chains  
-**What it is**  
-LLM explicitly generates **intermediate reasoning steps** over the retrieved evidence:  
-1. Extract key facts from each chunk.  
-2. Combine and reconcile facts.  
-3. Produce final answer, citing sources.
+**Benefits**
 
-**Pros**  
-- Better faithfulness; easier to debug.  
-- Can be reused across queries as a pattern.  
-- Plays nicely with evaluation tools (you can evaluate intermediate steps).
+- Better faithfulness and easier debugging.
+- Reasoning patterns can be reused across queries.
+- Intermediate steps are themselves evaluable, which suits automated evaluation tooling.
 
-**Cons**  
-- More tokens and latency.  
-- If not carefully constrained, chain-of-thought can hallucinate.
+**Trade-offs**
 
-**Mitigations**  
-- Keep reasoning steps short and almost **extractive** (“List relevant facts from the context”).  
-- Hide chain-of-thought from end user while logging it for internal eval.  
-- Put explicit instructions: “Only use facts from the context, quote them when possible.”
+- More tokens and higher latency.
+- Unconstrained chain-of-thought can introduce its own hallucinations.
 
-**Recent work & Cake angle**  
-Many recent RAG evaluations implicitly assume multi-step reasoning patterns.  
-For Cake:  
-- Offer **stock reasoning templates**: “Evidence extraction,” “Compare & contrast two policies.”  
-- Cake can log intermediate reasoning for **analytics** (where did it go wrong?).
+**Mitigations**
 
----
+- Keep reasoning steps short and largely extractive ("list the relevant facts from the context").
+- Hide intermediate reasoning from end users while logging it for internal evaluation.
+- Instruct explicitly: use only facts from the context, quoting where possible.
 
-#### 4.2 Retrieval-augmented Planning  
-**What it is**  
-LLM first **plans the steps** required to answer (including what to retrieve), then executes those steps, often with multiple retrieval iterations.
+**Relevant work.** Recent RAG evaluation efforts (FRAMES, ARES, and others) implicitly assume multi-step reasoning patterns. For Cake: offer stock reasoning templates such as "evidence extraction" and "compare and contrast two policies", and log intermediate reasoning for analytics on where answers go wrong.
 
-**Pros**  
-- Crucial for multi-hop or complex workflows (e.g., “find all policies impacted by regulation X and summarise changes since 2022”).  
-- Lets you use different retrievers for different sub-queries.
+### 4.2 Retrieval-Augmented Planning
 
-**Cons**  
-- More complicated architecture (agents, tools).  
-- Easy to over-engineer and blow your latency budget.
+**What it is.** The LLM first plans the steps required to answer — including what to retrieve — then executes the plan, often over multiple retrieval iterations.
 
-**Mitigations**  
-- Restrict to **two-stage or three-stage plans**, not free-form agents.  
-- Use coarse **“retrieval planner”** that decides query decomposition and which index to query.
+**Benefits**
 
-**Recent work & Cake angle**  
-- [Zhang et al., 2025] *“LevelRAG”*– high-level searcher + low-level searchers. :contentReference[oaicite:6]{index=6}  
-  - *Goal*: Use query decomposition into atomic sub-queries.  
-  - *For Cake*: Make **“retrieval plan”** an explicit data structure in the pipeline.  
-- [Verma et al., 2025] *“PLAN-RAG: Planning-guided Retrieval Augmented Generation”* – matches plan-then-retrieve paradigm. :contentReference[oaicite:7]{index=7}  
+- Essential for multi-hop and complex workflows (e.g. "find all policies affected by regulation X and summarise the changes since 2022").
+- Different retrievers can serve different sub-queries.
 
-For Cake: Make the pipeline modular enough to plug in a “planner” stage later.
+**Trade-offs**
+
+- More complex architecture (agents, tools).
+- Easy to over-engineer, with significant latency cost.
+
+**Mitigations**
+
+- Restrict plans to two or three stages rather than free-form agent loops.
+- Use a coarse retrieval planner that decides query decomposition and index routing.
+
+**Relevant work**
+
+- Zhang et al., 2025, *LevelRAG* — a high-level searcher coordinating multiple low-level searchers via query decomposition.
+- Verma et al., 2025, *PLAN-RAG: Planning-guided Retrieval Augmented Generation* — matches the plan-then-retrieve paradigm.
+- Work on question decomposition with cross-encoder re-ranking further supports staged, planned retrieval.
+
+For Cake: make the retrieval plan an explicit data structure in the pipeline rather than hidden prompt text, and keep the pipeline modular enough to add a planner stage later. Eventually, advanced users could supply simple planners (in Elixir) that choose retrieval strategy by question type.
 
 ---
 
-## 5. Guardrails Against LLM Bullshit
-[Back to table of contents](#table-of-contents)
+## 5. Guardrails and Faithfulness
 
-#### What this class is  
-Preventing or detecting hallucinations / unfaithful answers, especially in enterprise settings where “sounds plausible” but wrong can cost real money.
+This area covers preventing and detecting hallucinations and unfaithful answers — critical in enterprise settings, where a plausible-sounding but wrong answer carries real cost.
 
-#### Relevance to Cake  
-If you want enterprise adoption, you *must* have a **trust story**:
-- Faithfulness checks  
-- Citation quality  
-- Monitoring hallucination rates over time  
+**Relevance to Cake.** Enterprise adoption requires a credible trust story: faithfulness checks, citation quality, and monitoring of hallucination rates over time.
 
----
+### 5.1 Faithfulness Checks
 
-#### 5.1 Faithfulness Checks  
-**What it is**  
-Post-hoc or in-loop checks that the answer is **supported by retrieved context**:  
-- NLI-style models (entailment).  
-- LLM-as-judge scoring.  
-- Metamorphic tests (perturb inputs and see if answer behaves sanely).
+**What it is.** Post-hoc or in-loop verification that an answer is supported by the retrieved context: NLI-style entailment models, LLM-as-judge scoring, or metamorphic tests (perturb the inputs and check that the answer changes sensibly).
 
-**Pros**  
-- Catch egregious hallucinations.  
-- Can output confidence scores or trigger human review.
+**Benefits**
 
-**Cons**  
-- Extra models & cost.  
-- Judgments can be noisy, especially cross-domain.
+- Catches egregious hallucinations.
+- Can emit confidence scores or route answers to human review.
 
-**Mitigations**  
-- Use **binary “safe/unsafe”** thresholds rather than pretend you can get perfect calibration.  
-- Start with **LLM-as-judge** using a prompt (“Is this answer faithful to the citations?”).  
-- Only run heavy checks for high-risk tenants / queries.
+**Trade-offs**
 
-**Recent work & Cake angle**  
-- *FaithJudge & hallucination leaderboards (Vectara 2025)* – benchmarks faithfulness in RAG via LLM-as-judge.  
-- *“Correctness is Not Faithfulness in RAG” (Wallat et al. 2025)* – shows that just having a correct citation isn’t enough; citation must actually *cause* the answer.  
+- Additional models and cost.
+- Judgments are noisy, particularly across domains.
 
-For Cake:  
-- Short-term: simple **faithfulness scorer** using LLM-as-judge + context.  
-- Long-term: integrate metamorphic tests as part of **eval suite**.
+**Mitigations**
 
----
+- Use binary safe/unsafe thresholds rather than assuming precise calibration is achievable.
+- Start with LLM-as-judge using a simple faithful/unfaithful prompt against the citations.
+- Reserve heavier checks for high-risk tenants and queries.
 
-#### 5.2 “Show your citations” mode  
-**What it is**  
-Force the model to output **inline citations** tied to the retrieved chunks (e.g., [1], [2]) and map to doc IDs / URLs.
+**Relevant work**
 
-**Pros**  
-- Increases user trust.  
-- Enables automated evaluation of citation correctness / faithfulness.  
+- FaithJudge and the Vectara hallucination leaderboards (2025) — benchmark RAG faithfulness via LLM-as-judge.
+- Wallat et al., 2025, *Correctness is Not Faithfulness in RAG* — demonstrates that a correct citation is insufficient; the citation must actually ground the answer.
+- MetaRAG (2025) — a metamorphic testing framework for hallucination detection in production RAG systems where gold labels are unavailable.
+
+For Cake: short term, a simple faithfulness scorer using LLM-as-judge over the retrieved context; longer term, metamorphic tests integrated into the evaluation suite.
+
+### 5.2 Citation Mode
+
+**What it is.** Require the model to emit inline citations tied to retrieved chunks (e.g. `[1]`, `[2]`), mapped to document IDs and URLs.
+
+**Benefits**
+
+- Increases user trust.
+- Enables automated evaluation of citation correctness and faithfulness.
 - Encourages more grounded responses.
 
-**Cons**  
-- Models can mis-attribute citations.  
-- Formatting gets messy; UX must handle it.
+**Trade-offs**
 
-**Mitigations**  
-- Post-process citations (like CiteFix) instead of trusting raw LLM output.  
-- Evaluate citation correctness and fix or drop wrong ones.
+- Models can mis-attribute citations.
+- Formatting is fiddly and the UX must accommodate it.
 
-**Recent work & Cake angle**  
-- *CiteFix (2025)* – post-processing to improve citation accuracy with minimal cost.  
-- *RAGE & related work* – use citation metrics to evaluate RAG.  
+**Mitigations**
 
-For Cake:  
-- Make citations **mandatory** for “factual QA” modes.  
-- Build a generic **citation data model** (chunk_id, char_span, doc_url).  
-- Allow tenant UI to style citations however they want.
+- Post-process citations (in the style of CiteFix) rather than trusting raw model output.
+- Evaluate citation correctness; repair or drop incorrect citations.
 
----
+**Relevant work**
 
-## 6. Domain Adaptation / Structured Retrieval
-[Back to table of contents](#table-of-contents)
+- CiteFix (2025) — post-processing that improves citation accuracy at minimal cost.
+- RAGE and related work — citation metrics for evaluating and tuning RAG systems.
 
-#### What this class is  
-Moving beyond “documents as bags of words” to use **schemas, graphs, domain structure**:
-- Tables, APIs, CRM objects, product hierarchies  
-- Knowledge graphs  
-
-#### Relevance to Cake  
-This is where you can start morphing from “RAG framework” to “RAG substrate for enterprise systems.” Enterprises *already* have schemas and graphs; you need to plug into them.
+For Cake: make citations mandatory for factual QA modes; build a generic citation data model (`chunk_id`, `char_span`, `doc_url`); and let tenant UIs style citations as they see fit.
 
 ---
 
-#### 6.1 Schema-Aware Retrieval  
-**What it is**  
-Use domain schemas (tables, JSON, code, API descriptions) to:
-- Retrieve structured records, not just text.  
-- Embed both text and schema metadata.  
-- Let LLM reason over structured + unstructured evidence.
+## 6. Structured and Domain-Aware Retrieval
 
-**Pros**  
-- Better performance on tasks where values live in DBs or APIs.  
-- Ensures you’re reading latest data, not doc snapshots.
+This area moves beyond treating documents as bags of words, exploiting schemas, graphs, and domain structure: tables, APIs, CRM objects, product hierarchies, and knowledge graphs.
 
-**Cons**  
-- Needs connectors & schema mapping.  
-- Some LLMs struggle with complex structured prompts.
+**Relevance to Cake.** This is where Cake can evolve from "RAG framework" toward "RAG substrate for enterprise systems". Enterprises already have schemas and graphs; Cake needs to plug into them.
 
-**Mitigations**  
-- Do **hybrid retrieval**: structured queries (SQL/filters) + text search.  
+### 6.1 Schema-Aware Retrieval
+
+**What it is.** Use domain schemas (tables, JSON, code, API descriptions) to retrieve structured records rather than only text, embed both text and schema metadata, and let the LLM reason over structured and unstructured evidence together.
+
+**Benefits**
+
+- Better performance when the answer lives in a database or API rather than a document.
+- Reads current data instead of stale document snapshots.
+
+**Trade-offs**
+
+- Requires connectors and schema mapping.
+- Some LLMs handle complex structured prompts poorly.
+
+**Mitigations**
+
+- Combine structured queries (SQL, filters) with text search.
 - Summarise structured outputs into LLM-friendly snippets.
 
-**Recent work & Cake angle**  
-- *“Advancing RAG for Structured and Semi-Structured Data” (Cheerla et al., 2025)* – hybrid retrieval using BM25, dense, metadata-aware filtering for structured data.  
+**Relevant work.** Cheerla et al., 2025, *Advancing RAG for Structured and Semi-Structured Data* — hybrid retrieval combining BM25, dense retrieval, and metadata-aware filtering over structured data. For Cake: define a schema ingestion interface so that, given a table or API, Cake can build metadata-aware filters and join structured results with text context.
 
-For Cake:  
-- Define a **schema ingestion interface**: given a table or API, Cake knows how to:  
-  - Build metadata-aware filters  
-  - Join structured results with text context
+### 6.2 Graph-Augmented Retrieval
 
----
+**What it is.** Use a knowledge graph — pre-existing or derived from text — to expand retrieval via neighbours, organise context around entity and relationship paths, and guide multi-hop reasoning.
 
-#### 6.2 Graph-augmented Retrieval  
-**What it is**  
-Use a **knowledge graph** (or graph derived from text) to:  
-- Expand retrieval via neighbours  
-- Organise context around entity/relationship paths  
-- Guide multi-hop reasoning
+**Benefits**
 
-**Pros**  
-- Better at coverage of related facts.  
-- More coherent long answers.  
-- Especially good in complex domains (biomed, legal, enterprise orgs).
+- Better coverage of related facts.
+- More coherent long-form answers.
+- Particularly effective in complex domains (biomedical, legal, enterprise organisations).
 
-**Cons**  
-- Building/maintaining KGs is hard.  
-- Graph operations add latency.  
-- Graph must stay in sync with text.
+**Trade-offs**
 
-**Mitigations**  
-- Generate a **lightweight KG** from documents (entities + doc IDs).  
-- Link chunks to graph nodes (chunk linking).  
-- Use graph selectively for certain query types (multi-hop, cross-doc).
+- Building and maintaining knowledge graphs is expensive.
+- Graph operations add latency.
+- The graph must be kept in sync with the underlying text.
 
-**Recent work & Cake angle**  
-- *KG²RAG (Zhu et al., 2025)* – semantic retrieval → KG-guided expansion & organisation → paragraphs for RAG.  
-- *GGR (Liu et al., 2025)* – GNN-guided KG-RAG.  
-- *GraphRAG / Graph-based enterprise posts* – big wins on cross-document reasoning.  
+**Mitigations**
 
-For Cake:  
-- Don’t try to be “GraphRAG” v1, but:  
-  - Provide **hooks** for tenants who already have graphs.  
-  - Offer basic **doc-derived graph**: entities + doc IDs + links.
+- Generate a lightweight graph from documents (entities plus document IDs).
+- Link chunks to graph nodes.
+- Engage the graph selectively, for multi-hop and cross-document query types.
 
----
+**Relevant work**
 
-#### 6.3 Logit Bias for Domain Terms  
-**What it is**  
-Use logit bias / vocabulary steering so that the LLM:
-- Prefers domain-specific terms present in context.  
-- Avoids generic replacements (“employee handbook” vs “staff manual”).
+- Zhu et al., 2025, *KG²RAG* — semantic retrieval, then knowledge-graph-guided expansion and organisation into paragraphs for RAG.
+- Liu et al., 2025, *GGR* — GNN-guided KG-RAG that preserves key reasoning paths.
+- GraphRAG and related enterprise deployments report substantial gains on cross-document reasoning.
 
-**Pros**  
-- More consistent terminology.  
-- Reduces generic hallucinated phrasing.  
-- Useful for brand names, product names, internal acronyms.
+For Cake: do not attempt full GraphRAG in v1. Instead, provide hooks for tenants who already have graphs, and offer a basic document-derived graph (entities, document IDs, links).
 
-**Cons**  
-- Logit bias APIs are model-specific.  
-- Can cause weird outputs if misconfigured.
+### 6.3 Vocabulary Steering
 
-**Mitigations**  
-- Apply bias only on a **small curated term list** per tenant.  
-- Keep bias magnitudes modest; test thoroughly.
+**What it is.** Use logit bias or vocabulary steering so the model prefers domain-specific terms present in the context and avoids generic substitutions (e.g. "employee handbook" rather than "staff manual").
 
-**Recent work & Cake angle**  
-This is more practice than formal research; many enterprise RAG whitepapers mention **vocabulary steering**.  
+**Benefits**
 
-For Cake:  
-- Offer a **“preferred vocabulary” config** at tenant level.  
-- Later: auto-suggest vocabulary lists from their corpus.
+- More consistent terminology.
+- Less generic, hallucination-prone phrasing.
+- Useful for brand names, product names, and internal acronyms.
+
+**Trade-offs**
+
+- Logit bias APIs are model-specific.
+- Misconfiguration can produce degenerate output.
+
+**Mitigations**
+
+- Apply bias only to a small, curated term list per tenant.
+- Keep bias magnitudes modest and test thoroughly.
+
+**Relevant work.** This is established practice rather than formal research; enterprise RAG whitepapers describe vocabulary steering for brand-safe output. For Cake: offer a preferred-vocabulary configuration at tenant level, and later auto-suggest vocabulary lists from the tenant's corpus.
 
 ---
 
-## 7. Conversational Memory / Localised Thread State
-[Back to table of contents](#table-of-contents)
+## 7. Conversational Memory
 
-#### What this class is  
-Multi-turn RAG: keeping track of what’s been said, what’s retrieved before, what the user cares about over time.
+Multi-turn RAG requires tracking what has been said, what has been retrieved, and what the user cares about over time.
 
-#### Relevance to Cake  
-You already think like a distributed-systems engineer. Treat a conversation as a **stateful process**, not stateless Q/A. This is a natural place for Cake to overperform.
+**Relevance to Cake.** Cake's Elixir/OTP foundations suit this naturally: a conversation is a stateful process, not a stateless question-answer exchange. This is an area where Cake can outperform.
 
----
+### 7.1 Conversation-Aware Retrieval
 
-#### 7.1 Short-term memory embeddings (conversation-aware retrieval)  
-**What it is**  
-Embed conversation turns and use them:  
-- As additional retrieval signals (“the user and I have been talking about VPN, not HR”)  
-- To disambiguate pronouns and references.
+**What it is.** Embed conversation turns and use them as additional retrieval signals (the conversation has been about VPNs, not HR) and to disambiguate pronouns and references. This constitutes the conversation's short-term memory.
 
-**Pros**  
-- Better contextual relevance.  
-- Reduces repeated clarifications.
+**Benefits**
 
-**Cons**  
-- Memory grows over time; retrieval over it can get expensive.  
-- Risk of retrieving outdated context (e.g., superseded answers).
+- Better contextual relevance.
+- Fewer repeated clarification requests.
 
-**Mitigations**  
-- Keep short-term memory **bounded** (last N turns + summary).  
+**Trade-offs**
+
+- Memory grows over time, and retrieval over it becomes expensive.
+- Risk of retrieving outdated context, such as superseded answers.
+
+**Mitigations**
+
+- Bound short-term memory: the last N turns plus a running summary.
 - Summarise older turns.
 
-**Recent work & Cake angle**  
-- *RAG memory surveys (2025)* – review of memory architectures in conversational LLMs + vector DB + RAG.  
-- *Multi-turn RAG benchmarks (MTRAG)-style* – evaluate multi-turn retrieval & reasoning.  
+**Relevant work.** Surveys of RAG-driven memory architectures (2025) and multi-turn benchmarks such as MTRAG evaluate multi-turn retrieval and reasoning directly. For Cake: provide a built-in conversation memory store and retrieval hook, separate from the main knowledge base, with tenant-tunable memory length and summarisation strategy.
 
-For Cake:  
-- Provide a built-in **conversation memory store** and retrieval hook, separate from the main KB.  
-- Let tenants tune: memory length, summarisation strategy.
+### 7.2 Long-Term Memory
 
----
+**What it is.** Persist distilled facts about the user or an ongoing task — preferences, company-specific decisions, prior agreements — as structured objects or summarised notes.
 
-#### 7.2 Long-term memory (summaries, facts, commitments)  
-**What it is**  
-Persist distilled facts about the user or ongoing task:  
-- User prefs, company-specific decisions, “we agreed X last week”  
-- Stored as structured objects or summarized notes.
+**Benefits**
 
-**Pros**  
-- Supports long-lived workflows and agents.  
-- Reduces re-asking the same questions.
+- Supports long-lived workflows and agents.
+- Avoids re-asking questions already answered.
 
-**Cons**  
-- Risk of storing wrong information.  
-- Can conflict with up-to-date KB content.
+**Trade-offs**
 
-**Mitigations**  
-- Include **timestamps and confidence** on stored facts.  
-- Periodically reconcile with authoritative sources.
+- Risk of persisting incorrect information.
+- Stored facts can conflict with newer knowledge-base content.
 
-**Recent work & Cake angle**  
-Long-term memory is covered in memory architecture surveys.
+**Mitigations**
 
-For Cake:  
-- Offer a **long-term memory interface**:  
-  - A simple key-value or fact-graph store  
-  - LLM helpers to update it cautiously.
+- Attach timestamps and confidence levels to stored facts.
+- Periodically reconcile memory against authoritative sources.
 
----
+**Relevant work.** Long-term memory is covered by conversational memory surveys and multi-turn RAG evaluation work. For Cake: offer a long-term memory interface — a simple key-value or fact-graph store, with LLM helpers that update it conservatively.
 
-#### 7.3 Multi-turn reference disambiguation  
-**What it is**  
-Resolve pronouns and shorthand:  
-- “That policy” → which one?  
-- “The second option you mentioned” → map back to specific chunk/doc.
+### 7.3 Multi-Turn Reference Disambiguation
 
-**Pros**  
-- Critical for enterprise conversational UX.  
+**What it is.** Resolve pronouns and shorthand across turns: "that policy" → which policy? "the second option you mentioned" → which chunk or document?
+
+**Benefits**
+
+- Critical for enterprise conversational UX.
 - Reduces misinterpretation.
 
-**Cons**  
-- Needs either:  
-  - LLM-based resolution over recent turns  
-  - or a graph of “mentions” and their bindings
+**Trade-offs**
 
-**Mitigations**  
-- Use a small **coreference resolver** over recent turns.  
-- Use retrieval over conversation memory (“find which entity was just discussed”).
+- Requires either LLM-based resolution over recent turns or a graph of mentions and their bindings.
 
-**Recent work & Cake angle**  
-Benchmarks like MTRAG (2025) focus on multi-turn QA where context tracking is essential.
+**Mitigations**
 
-For Cake:  
-- Make **reference resolution** an explicit step in the pipeline:  
-  - Raw user query → rewritten, de-referenced query
+- Use a small coreference resolver over recent turns.
+- Use retrieval over conversation memory to find the most recently discussed entity.
+
+**Relevant work.** Multi-turn benchmarks such as MTRAG (2025) centre on QA where context tracking is essential. For Cake: make reference resolution an explicit pipeline step that rewrites the raw user query into a fully de-referenced query.
 
 ---
 
-## 8. Evaluation & Feedback Loops
-[Back to table of contents](#table-of-contents)
+## 8. Evaluation and Feedback Loops
 
-#### What this class is  
-You cannot treat this as an afterthought. Real RAG deployment = constant **measurement**:  
-- Retrieval quality  
-- Generation faithfulness  
-- Drift over time  
+Evaluation cannot be an afterthought. Production RAG requires constant measurement of retrieval quality, generation faithfulness, and drift over time.
 
-#### Relevance to Cake  
-A major differentiator for Cake can be **first-class RAG evaluation tooling**, instead of “you figure it out with LangChain / random dashboards.”
+**Relevance to Cake.** First-class RAG evaluation tooling is a major potential differentiator, against the status quo of ad-hoc dashboards assembled per deployment.
 
----
+### 8.1 Synthetic Query Evaluation
 
-#### 8.1 Synthetic Queries for Recall Testing  
-**What it is**  
-Use LLMs to generate synthetic:  
-- queries  
-- answers  
-- sometimes labels  
-from your corpus; then evaluate retrieval + generation performance.
+**What it is.** Use LLMs to generate synthetic queries, answers, and sometimes labels from the corpus, then evaluate retrieval and generation performance against them.
 
-**Pros**  
-- Cheap way to build eval sets without full human labeling.  
-- Lets you compare chunking/retrieval configs quickly.  
-- Enables automated acceptance checks before deploying changes.
+**Benefits**
 
-**Cons**  
-- Synthetic queries may not match real user distribution.  
-- LLM-generated answers can be wrong, polluting labels.
+- Builds evaluation sets cheaply, without full human labelling.
+- Enables rapid comparison of chunking and retrieval configurations.
+- Supports automated acceptance checks before deploying changes.
 
-**Mitigations**  
-- Mix in **small human-validated subset**.  
+**Trade-offs**
+
+- Synthetic queries may not match the real user distribution.
+- LLM-generated answers can be wrong, polluting the labels.
+
+**Mitigations**
+
+- Mix in a small human-validated subset.
 - Use LLM-as-judge for scoring, not as ground truth.
 
-**Recent work & Cake angle**  
-- *ARES (Saad-Falcon et al., 2024)* – automated RAG evaluation using synthetic queries + LLM judges.  
-- *FRAMES (2024)* – unified dataset for factuality, retrieval, reasoning in RAG.  
+**Relevant work**
 
-For Cake:  
-- Build a **“synthetic eval kit”**:  
-  - Given a corpus, auto-generate 100-500 synthetic queries + answers  
-  - Run them through different Cake pipelines  
-  - Output recall/precision/faithfulness metrics  
+- Saad-Falcon et al., 2024, *ARES* — automated RAG evaluation using synthetic queries and LLM judges.
+- FRAMES (2024) — a unified dataset for evaluating factuality, retrieval, and reasoning in RAG.
+- Synthetic test collections for IR (2024) — fully synthetic IR benchmarks built with LLMs.
 
----
+For Cake: build a synthetic evaluation kit — given a corpus, auto-generate 100–500 synthetic queries and answers, run them through different Cake pipelines, and report recall, precision, and faithfulness metrics.
 
-#### 8.2 “Drift detection” for content updates  
-**What it is**  
-Monitor changes over time:  
-- **Data drift** – new docs, updated policies  
-- **Concept drift** – meaning of queries changes  
-- **Model drift** – new model versions behave differently  
+### 8.2 Drift Detection
 
-**Pros**  
-- Prevents silent degradation.  
-- Gives you a story for enterprises: “We know when it breaks.”  
+**What it is.** Monitor change over time: *data drift* (new documents, updated policies), *concept drift* (query meanings shift), and *model drift* (new model versions behave differently).
 
-**Cons**  
-- Non-trivial to implement; metrics can be fuzzy.  
+**Benefits**
+
+- Prevents silent degradation.
+- Gives enterprises confidence that failures will be detected.
+
+**Trade-offs**
+
+- Non-trivial to implement, and the metrics can be fuzzy.
 - Requires historical logs, not just snapshots.
 
-**Mitigations**  
-- Track simple KPIs:  
-  - context recall  
-  - answer faithfulness  
-  - user feedback rates  
+**Mitigations**
+
+- Track simple KPIs: context recall, answer faithfulness, user feedback rates.
 - Alert on significant deltas.
 
-**Recent work & Cake angle**  
-- Industry resources on **retrieval drift monitoring** and concept-drift adaptation.  
-- RAG evaluation pieces emphasising continuous monitoring in production.  
-
-For Cake:  
-- Incorporate **drift dashboards** at the framework level:  
-  - by corpus  
-  - by tenant  
-  - before/after model version changes  
+**Relevant work.** Industry material on retrieval drift monitoring and concept-drift adaptation, and RAG evaluation literature emphasising continuous monitoring in production. For Cake: incorporate drift dashboards at the framework level — per corpus, per tenant, and before/after model version changes.
 
 ---
 
-## Recommendations for Cake
+## Recommendations
 
-### A. Immediate Priorities (next MVP iterations)  
-1. **Lock in Retrieval as a configurable pipeline**  
-   - Implement **hybrid retrieval** in OpenSearch: BM25 + dense or neural sparse + dense.  
-   - Add a **simple reranker**: start with a small cross encoder.  
-   - Add **optional query expansion**: start with HyDE-style “generate hypothetical answer → embed.”
+This section translates the survey into practice: what to build now, what to adjust in the MVP design, and where Cake can establish an early edge.
 
-2. **Chunking v1.5 – metadata-aware, with overlap**  
-   - Implement **metadata-aware semantic chunking** using headings/sections.  
-   - Support configurable **overlap** per index.  
-   - Store basic metadata: doc_id, section_title, page, etc.  
+### A. Immediate Priorities
 
-3. **Context Builder abstraction**  
-   - Extract from your current pipeline a formal **ContextBuilder**:  
-     - dedupe hits  
-     - group by document  
-     - attach metadata/roles  
-   - Provide two strategies:  
-     - Simple “top-k raw chunks”  
-     - “Grouped by document” with basic summarisation  
+1. **Lock in retrieval as a configurable pipeline.**
+   - Implement hybrid retrieval in OpenSearch: BM25 + dense, or neural sparse + dense, with tunable weights.
+   - Add a simple re-ranker, starting with a small cross-encoder on CPU or inexpensive GPU.
+   - Add optional query expansion, starting with HyDE-style hypothetical-answer embedding.
 
-4. **Citations and Logging**  
-   - Add a **mandatory citation mode** for factual QA paths.  
-   - Log retrieved chunk IDs, citations used, faithfulness scores (basic LLM-as-judge).  
+2. **Chunking v1.5: metadata-aware, with overlap.**
+   - Implement metadata-aware semantic chunking using headings and sections where available.
+   - Support configurable overlap per index.
+   - Store basic metadata: `doc_id`, `section_title`, `page`, and similar fields.
 
-5. **Basic Evaluation Harness**  
-   - Implement a tiny ARES-inspired eval workflow:  
-     - synthetic queries from corpus  
-     - LLM-as-judge scoring of answer relevance/faithfulness  
+3. **Context builder abstraction.**
+   - Extract a formal `ContextBuilder` from the current pipeline: deduplicate hits, group by document, attach metadata and roles.
+   - Provide two strategies initially: simple top-k raw chunks, and grouped-by-document with basic summarisation.
 
----
+4. **Citations and logging.**
+   - Add a mandatory citation mode for factual QA paths.
+   - Log retrieved chunk IDs, citations used, and basic LLM-as-judge faithfulness scores.
 
-### B. Changes to the MVP Design  
-- **Make pipelines first-class**: retrieval/generation as structured Elixir pipelines.  
-- **Design document schema for multi-representation**: allow multiple vector fields, rich metadata.  
-- **Split memory from KB**: keep conversation memory in a separate index/store from main corpus.  
+5. **Basic evaluation harness.**
+   - Implement a small ARES-inspired workflow: synthetic queries generated from the corpus, scored for relevance and faithfulness by LLM-as-judge.
 
----
+Together these are enough to position Cake as a serious framework rather than a do-it-yourself assembly of parts.
 
-### C. Most Relevant to Scaling Cake  
-- **Configurable Retrieval Recipes**: Each customer gets a slightly different recipe (hybrid weights, chunking strategy, reranking depth).  
-- **Evaluation & Monitoring Built-In**: Cake ships with synthetic eval, faithfulness scoring, drift dashboards.  
-- **Hooks for Structure (Schemas, Graphs)**: Allow ingestion of SQL/NoSQL tables + graphs as retrieval sources.  
+### B. MVP Design Changes
 
----
+None of this requires a rewrite, but a few structural decisions matter now:
 
-### D. Potential Competitive Advantages to Seize Early  
-1. **Multi-Representation Chunking as First-Class Feature** – Most tools treat chunks as single vector; you offer multiple embeddings per chunk with schema and weighting.  
-2. **Built-in Chunking Evaluation Lab** – Let customers test multiple chunking configs and see metrics side-by-side.  
-3. **Conversation-Aware Enterprise RAG** – Built-in short & long term memory and multi-turn tracking, not just single Q/A.  
-4. **Evaluation as Part of the Core Story** – Not optional; you market Cake as “we build, measure, monitor your RAG” not just “we build it”.
+- **Make pipelines first-class.** Represent retrieval and generation as structured Elixir pipelines — `query_normalize → planner (optional) → retriever(s) → reranker → context_builder → generator → guardrails` — with configurations stored declaratively (YAML/JSON) so tenants can define pipelines without code.
+- **Design the document schema for multi-representation.** Even before it is fully exploited, define the OpenSearch schema to allow multiple vector fields (raw, summary, entities) and rich metadata, avoiding migration pain later.
+- **Split memory from the knowledge base.** Keep conversational memory in a separate index or store from the main corpus, with a clean API boundary between conversation-memory retrieval and corpus retrieval.
 
----
+### C. Scaling Considerations
 
-### Reality Check / Obstacles  
-- **Risk 1 – Overengineering early**: You have the brain to chase LevelRAG/graphs and Gaussian QE spaces. The danger is building “RAG research lab of your dreams” instead of a sellable v1.  
-  - *Mitigation*: Ship **Hybrid + Rerank + Semantic chunking + Citations + Basic eval** first; everything else is **Phase 2**.  
-- **Risk 2 – Self-punishment loops via perfectionism**: If you catch yourself thinking “it’s not worth launching unless it’s state-of-the-art across all eight dimensions,” that’s the sabotage talking, not the engineer.  
-  - *Mitigation*: Define a **hard MVP threshold** and move.  
+For high-touch enterprise implementations, the following matter most:
 
----
+- **Configurable retrieval recipes.** Each customer will need slightly different hybrid weights, chunking strategy, and re-ranking depth. These must be adjustable in configuration, not code.
+- **Evaluation and monitoring built in.** Shipping with a synthetic evaluation harness, faithfulness scoring, and drift dashboard hooks supports the pitch that Cake does not just build a RAG system but monitors and tunes it over time.
+- **Hooks for structure.** Full graph-augmented retrieval is not needed on day one, but the extension points for graph-based retrieval and for ingesting SQL/NoSQL tables with domain-aware filters should exist early.
 
-**If you like**, next step I can turn this into a **Cake “tech vision” doc** or design the **exact Elixir module boundaries** for the pipeline so you can begin cutting code without thrash.
-1. Retrieval (because naive vector search is mid)
-What this class is
+### D. Early Differentiators
 
-This is everything about how you select candidate chunks from the corpus before the LLM sees anything. If retrieval sucks, nothing downstream fixes it. Hybrid search, reranking, and query expansion are three levers to boost recall and precision beyond “cosine similarity on a single embedding.”
+1. **Multi-representation chunking as a first-class feature.** Most tools still treat a chunk as a single embedding. Cake can define a multi-vector document schema and provide stock pipelines for combining representations — a natural fit for its schema-design and OpenSearch strengths.
+2. **A built-in chunking evaluation lab.** Almost no framework productises Chroma-style chunking evaluation. Cake could let a customer upload a corpus, try three or four chunking configurations, and compare metrics and example queries side by side.
+3. **Conversation-aware enterprise RAG.** Many products still treat every query as stateless. Cake can bake in short-term memory embeddings, basic long-term memory, and multi-turn evaluation in the style of MTRAG — positioning Cake for ongoing knowledge work rather than single questions.
+4. **Evaluation as part of the core story.** Building on ARES and FRAMES, make evaluation part of the standard Cake deployment: the pitch is measurement, not just construction.
 
-In real RAG systems, retrieval is often 70–80% of the quality story. 
-ACL Anthology
-+1
+### Risks
 
-Relevance to Cake
-
-Cake is meant to be a framework, not just a toy app. That means your retrieval layer has to be:
-
-Configurable (per-tenant / per-domain retrieval recipes)
-
-Composable (query → retrieve → re-rank → post-filter)
-
-Observable (you can see why a query failed)
-
-Hybrid, reranking, and query expansion should be first-class pipeline stages Cake exposes.
-
-1.1 Hybrid Search
-
-What it is
-
-Combine sparse (BM25 / neural sparse) and dense (embeddings) retrieval into one ranked list. Either via score fusion (e.g., weighted sum) or multi-stage (BM25 → dense filter or vice versa). Hybrid is now broadly “best default” for RAG. 
-ACL Anthology
-+2
-Amazon Web Services, Inc.
-+2
-
-Pros
-
-Much better robustness on:
-
-rare terms, IDs, codes (BM25/neural sparse)
-
-paraphrases and fuzzy language (dense)
-
-Works well on enterprise KBs that mix jargon with natural language.
-
-Plays nicely with OpenSearch (you already get BM25 + dense + neural sparse). 
-Amazon Web Services, Inc.
-
-Cons
-
-Score fusion is fiddly (how to weight sparse vs dense).
-
-Latency and infra complexity (multiple retrievers).
-
-Can over-emphasize long docs or spammy fields if BM25 isn’t tuned.
-
-Mitigations
-
-Learn weights per index or per tenant (simple grid search or small regression model).
-
-Normalize scores (z-score or min–max per retriever).
-
-Use metadata filters and field-specific boosts to keep BM25 sane (e.g., title > body).
-
-Recent work & Cake angle
-
-“Searching for Best Practices in RAG” (Wang et al. 2024) – large empirical study; finds that Hybrid Search + HyDE-style query rewriting is often the best tradeoff of accuracy vs latency across benchmarks. 
-ACL Anthology
-
-Goal: Benchmark a ton of RAG configs (retrievers, chunking, reranking).
-
-Practicality: Extremely high; these are literally off-the-shelf setups.
-
-Future: More adaptive hybrids (e.g., dynamic weighting per query).
-
-For Cake: Treat their recommended “Hybrid + HyDE” recipe as a default retrieval preset.
-
-AWS OpenSearch neural sparse + dense hybrid blog (2024) – shows that combining dense vectors with OpenSearch’s neural sparse search improves RAG retrieval for KBs, often more simply than BM25+dense. 
-Amazon Web Services, Inc.
-
-Goal: Demonstrate practical hybrid on real infra (OpenSearch).
-
-Practicality: Maximal—this is exactly your stack.
-
-For Cake:
-
-Build a standard OpenSearch hybrid retriever module: BM25 or neural sparse + dense with tunable weights and field boosts.
-
-Offer config templates like:
-
-“Docs KB hybrid”
-
-“Code/docs hybrid”
-
-“FAQ-heavy KB hybrid”
-
-Domain-specific hybrid QA (2024/2025 work like “Domain-specific Question Answering with Hybrid Search”) – shows hybrid dense+BM25 significantly boosts QA in specialized domains. 
-arXiv
-
-Independent research ideas
-
-Learn per-tenant fusion weights from minimal feedback (clicks / thumbs up/down).
-
-Evaluate whether OpenSearch neural sparse + dense beats classic BM25+dense for the specific enterprise domains you target and publish that as a “Cake Retrieval Study.”
-
-1.2 Re-ranking Pipelines
-
-What it is
-
-Two-stage retrieval: first get a big candidate pool (e.g. top-50 or top-100 chunks), then score each candidate more precisely with a cross encoder or LLM-as-reranker, producing a much better top-5. 
-Pinecone
-+1
-
-Pros
-
-Huge quality bump, especially in noisy KBs (duplicate docs, irrelevant boilerplate).
-
-You can keep recall high while controlling LLM context size.
-
-Great in high-stakes domains (compliance, finance, medical).
-
-Cons
-
-Extra latency (heavy model scoring 50–100 candidates).
-
-Additional infra complexity (GPU/CPU serving, batching, caching).
-
-If your baseline retrieval is garbage, reranking can’t fix it.
-
-Mitigations
-
-Use efficient cross encoders (e.g., MiniLM, MPNet) and batch across tenants.
-
-Cache reranker scores for repeated queries or canonical question templates.
-
-Use adaptive candidate set sizes (k=30 for short queries, k=100 for multi-hop).
-
-Recent work & Cake angle
-
-KG²RAG (Zhu et al., 2025) – combines semantic retrieval with KG-guided organization and reranking; uses cross-encoders to measure paragraph-level relevance guided by a knowledge graph structure. 
-ACL Anthology
-+1
-
-Goal: Improve coherence and relevance by using KG structure plus reranking.
-
-Practicality: Moderate–high for enterprises that have graphs or can derive them (CRM, product catalogs).
-
-Future: Graph-aware rerankers that treat “document + neighbors” as one unit.
-
-For Cake: Aligns strongly with a “structured retrieval preset”: graph + dense + rerank.
-
-Biomedical RAG with cross-encoder + GPT reranking (2025) – “Beyond Retrieval: Ensembling Cross-Encoders and GPT” 
-arXiv
-
-Goal: Use ensembles of cross-encoders and LLM rerankers for PubMed QA.
-
-Practicality: High in domains with standard corpora; cost goes up.
-
-For Cake: Inspiration for pluggable reranker backends (“cheap cross-encoder,” “LLM reranker,” “ensemble”) configurable per tenant.
-
-Tons of industry writeups (Pinecone, Databricks, blogs) show reranking as one of the simplest big wins for RAG. 
-Pinecone
-+2
-Nb Data
-+2
-
-Independent research ideas
-
-Re-rank not chunks but chunk-groups (e.g. all chunks from the same doc or section).
-
-Use multi-objective reranking for enterprise: relevance + recency + access control.
-
-1.3 Query Expansion
-
-What it is
-
-Automatically expand or rewrite a user query into richer representations: paraphrases, related terms, or synthetic “ideal answers” whose content you then retrieve against.
-
-Includes HyDE-style “generate a hypothetical answer, embed that” and LLM-based query expansion variants. 
-ACL Anthology
-+1
-
-Pros
-
-Fixes short or vague queries (“VPN broken”, “hr policy maternity”).
-
-Bridges lexical gaps (synonyms, abbreviations, multilingual).
-
-Especially strong when combined with hybrid retrieval.
-
-Cons
-
-Can introduce drift if expansions hallucinate irrelevant concepts.
-
-High compute if you generate many expansions per query.
-
-Can hurt precision by pulling in tangential docs.
-
-Mitigations
-
-Limit to 2–3 expansions and keep them short.
-
-Use retrieval feedback: discard expansions whose retrieved set has low similarity to others.
-
-Add a “no expansion” path and AB compare.
-
-Recent work & Cake angle
-
-LevelRAG (Zhang et al., 2025) – integrates a high-level searcher with multiple low-level searchers (sparse, web, dense) and decouples query rewriting from any single retriever. 
-arXiv
-+1
-
-Goal: Make query rewriting a general planning layer, not hard-tied to dense retrievers.
-
-Practicality: High at the “framework” level; more complex to implement, but exactly your vibe.
-
-For Cake: You can steal this idea as your “retrieval planner” abstraction: one module does query decomposition/expansion, and then routes sub-queries across hybrid retrievers.
-
-LLM-QE (Pan et al., 2025) – LLM-based query expansion with a Gaussian-kernel semantic space that refines multiple expansion vectors and improves dense retrieval. 
-MDPI
-+1
-
-Goal: Make expansions not just longer, but better-positioned in embedding space.
-
-Practicality: Medium; needs infrastructure for multiple embeddings + kernel weighting.
-
-For Cake: Future research direction, not MVP – but you could implement a simplified “multi-embedding expansion” mode later.
-
-“Exploring Best Practices of Query Expansion with LLMs for IR” (Zhang et al., 2024) – systematic study of LLM-based query expansion (Query2Doc variants). 
-ACL Anthology
-+1
-
-Takeaway: QE helps weaker retrievers more; strong dense models already do some semantic expansion.
-
-For Cake: You can make QE optional and mostly useful when tenants use cheaper embeddings.
-
-Independent research
-
-Evaluate per-tenant whether QE helps (you can do small offline tests).
-
-Try RAG-based QE (as in Olivera 2025) where expansions are themselves retrieved and scored. 
-SciTePress
-+1
-
-2. Chunking
-What this class is
-
-Chunking is how you cut raw docs into embedding units. You know this already, but the literature is loud now: chunking strategy can easily swing recall by ~5–10 percentage points across real RAG tasks. 
-Chroma Research
-+2
-Firecrawl - The Web Data API for AI
-+2
-
-Relevance to Cake
-
-Cake as a framework should treat chunkers as pluggable strategies with:
-
-Defaults (recursive char, semantic, metadata-aware)
-
-Domain-specific presets (PDF reports vs tickets vs code)
-
-Evaluation harnesses (so tenants can see how chunking changes retrieval)
-
-2.1 Semantic Chunking
-
-What it is
-
-Use document structure and semantics (headings, paragraphs, list boundaries, LLM segmenters) instead of dumb “every 512 chars.” 
-Databricks Community
-+2
-Medium
-+2
-
-Pros
-
-Higher chance that a chunk is self-contained enough to answer a question.
-
-Fewer “cut in the middle of a concept” issues.
-
-Better for long enterprise docs (policies, SOPs, contracts).
-
-Cons
-
-More complex ingestion (you need robust parsing).
-
-PDF/HTML soup can break structural cues.
-
-Latency / cost if you use an LLM for segmentation (multimodal chunkers). 
-arXiv
-
-Mitigations
-
-Use cheap deterministic rules first (headings, sections) and only fall back to LLM chunking for ugly docs.
-
-Cache multimodal chunk results aggressively.
-
-Log “chunk usefulness” over time and refine heuristics.
-
-Recent work & Cake angle
-
-Chroma “Evaluating Chunking Strategies for Retrieval” (2024) – rigorous analysis of chunking strategies using Recall, Precision, IoU-style metrics; shows that semantic & metadata-aware chunkers beat naive ones. 
-Chroma Research
-+2
-GitHub
-+2
-
-Practicality: Very high; they open-sourced tooling.
-
-For Cake:
-
-Bake in a chunking-eval lab similar to Chroma’s.
-
-Expose that as a Cake feature – this is something almost no “framework” productizes well.
-
-“Evaluating Advanced Chunking Strategies for RAG” (Merola et al., 2025) – compares late chunking vs contextual retrieval. Contextual retrieval (fetch bigger context then slice) keeps coherence but costs more; late chunking is efficient but loses detail. 
-arXiv
-+1
-
-For Cake: Suggests a “contextual retrieval mode” as an advanced option for certain high-value tenants.
-
-Multimodal chunking for PDFs (2025 paper on multimodal RAG chunking) – uses LMMs to handle tables, figures, cross-page structures. 
-arXiv
-
-Future: Important for enterprises with heavy reporting / PowerPoints.
-
-2.2 Overlapping Windows
-
-What it is
-
-Allow chunks to overlap so that boundary regions appear in multiple chunks (e.g., 1k tokens with 200-token overlap).
-
-Pros
-
-Reduces “I cut out the crucial sentence” errors.
-
-Essential for code, protocols, stepwise procedures.
-
-Makes retrieval more tolerant to segmentation choices.
-
-Cons
-
-Increases index size and ingest cost.
-
-Can amplify duplicates, leading to retrieval redundancy.
-
-More noise if reranker / generator isn’t smart.
-
-Mitigations
-
-Tune overlap based on doc type (large for code, small for FAQs).
-
-Combine with deduplication in retrieval (merge overlapping hits).
-
-Use chunk grouping at context-assembly time.
-
-Recent work & Cake angle
-
-Most of the recent chunking studies (Chroma, Snowflake, Firecrawl, etc.) treat overlap as a tunable hyperparameter and show that moderate overlap (10–30%) is generally beneficial, but excessive overlap gives diminishing returns. 
-jxnl.co
-+3
-Chroma Research
-+3
-Firecrawl - The Web Data API for AI
-+3
-
-For Cake:
-
-Allow per-index overlap configuration.
-
-Provide “profiles” like:
-
-“Long-form policy docs” – moderate overlap.
-
-“Code/API docs” – higher overlap.
-
-2.3 Multi-Representation Chunks
-
-What it is
-
-Store multiple embeddings per chunk, each capturing a different aspect: raw text, summary, entities, maybe separate embeddings for title vs body. Sometimes called multi-vector embeddings. 
-baobabtech.ai
-+2
-newsletter.theaiedge.io
-+2
-
-Pros
-
-Better retrieval for:
-
-Entity-heavy queries (use NER embedding).
-
-Conceptual queries (use summary embedding).
-
-Allows you to weight different views at query time.
-
-Cons
-
-More storage.
-
-More complex retrieval logic.
-
-Index maintenance is harder (you now have multiple fields per chunk).
-
-Mitigations
-
-Start with just two representations: full chunk and summary/entities.
-
-Use OpenSearch’s support for multiple vector fields per document.
-
-Use simple fusion rules per query type.
-
-Recent work & Cake angle
-
-Industry writeups (Baobab, AI Edge, vector DB blogs) show multi-vector yielding significant improvements for heterogenous data. 
-baobabtech.ai
-+2
-newsletter.theaiedge.io
-+2
-
-RAG evolution reviews note that token-level or multi-vector representations are increasingly common for complex doc structures. 
-ragflow.io
-+1
-
-For Cake:
-
-This is a killer differentiator if you do it cleanly:
-
-Offer a “multi-representation schema” as part of the ingestion config.
-
-Let advanced users plug in their own summarizers/NERs to define extra views.
-
-Independent research:
-
-Study which combinations of representations give best returns for enterprise KBs (e.g. title + summary vs summary + entities).
-
-Build a small paper: “Multi-Representation Chunking for Enterprise RAG with OpenSearch” and publish results.
-
-3. Context Assembly
-What this class is
-
-You’ve got a set of retrieved chunks. Now you decide what to send to the LLM and how. Context assembly is about:
-
-Removing duplicates
-
-Grouping related chunks
-
-Annotating their roles
-
-This is hugely impactful for hallucinations and coherence, especially on long contexts. 
-OpenAI Developer Community
-+1
-
-Relevance to Cake
-
-Most frameworks treat this as an afterthought. You can make it a first-class pipeline stage:
-
-A “context builder” that’s pluggable per tenant.
-
-Built-in strategies: simple top-k, grouped by document, grouped by section/role, etc.
-
-3.1 Deduplication and Consolidation
-
-What it is
-
-Deduplication: removing near-identical chunks (same text, or high cosine sim).
-
-Consolidation: merging multiple related chunks into concise summaries before sending to the LLM.
-
-Pros
-
-Less wasted context budget.
-
-Reduces conflicting statements.
-
-Makes answers more grounded and concise.
-
-Cons
-
-Summarization can itself hallucinate or drop critical detail.
-
-Extra latency for consolidation step.
-
-Requires careful citation tracking.
-
-Mitigations
-
-Use extractive summaries when possible (pull key sentences instead of abstractive rewrites).
-
-Limit consolidation to chunks from the same doc/section.
-
-Keep links back to all source chunk IDs for citations.
-
-Recent work & Cake angle
-
-Most RAG best-practice guides emphasize that naive “dump the top N chunks as-is” is suboptimal; some use post-retrieval clustering + summarization. 
-Pat McGuinness
-+2
-morphik.ai
-+2
-
-You’re well-positioned to:
-
-Implement a document-level context builder: retrieve chunks → cluster by doc → summarize per doc.
-
-Add a “strict mode” where only exact, non-consolidated chunks are used for high-risk queries.
-
-3.2 Section-aware Assembly
-
-What it is
-
-Group chunks by document sections (e.g., “Section 3: Billing Disputes”) or conceptual “sections” (background, constraints, examples), and feed this structure to the LLM.
-
-Pros
-
-Reduces context confusion by giving the model labeled buckets.
-
-Works well for multi-doc answers (“Policy A says X, Policy B says Y”).
-
-Helps multi-hop reasoning—model sees which chunk is doing what.
-
-Cons
-
-Requires good metadata at ingest (parse headings, hierarchy).
-
-Not all corpora have clean structure (ticket logs, chat).
-
-Prompts get more complex.
-
-Mitigations
-
-For unstructured data, use simple heuristics (source, date, doc type) as pseudo-sections.
-
-Build default prompt scaffolds (“You are given multiple sections: …”).
-
-Recent work & Cake angle
-
-OpenAI’s “document sections” pattern and similar community resources explicitly show that sectioned context improves RAG QA quality. 
-OpenAI Developer Community
-+1
-
-For Cake:
-
-Include a section-aware context template as a core feature.
-
-Expose structured prompts where you pass context as {definitions:[], procedures:[], examples:[]}.
-
-3.3 Context Windows with Roles
-
-What it is
-
-Assign roles to chunks: facts, definitions, constraints, examples, user history, etc., and instruct the LLM how to use them (e.g., “prioritize constraints over examples when conflicts occur”).
-
-Pros
-
-Makes answers more deterministic and policy-compliant.
-
-Lets you handle conflicts (policy vs example) more predictably.
-
-Good fit for enterprise compliance / SOP flows.
-
-Cons
-
-Requires classification of chunks (manual or model-based).
-
-More complicated prompts and context-building.
-
-Mitigations
-
-Start with simple roles based on metadata or heuristics (title, path).
-
-Add optional LLM-based role classification as an offline pipeline.
-
-Recent work & Cake angle
-
-This is less a specific paper and more a pattern emerging in enterprise RAG whitepapers and technical deep dives, which emphasize role-annotated context for auditability and consistency. 
-Shaping the future together
-+2
-smarttechlabs.de
-+2
-
-For Cake:
-
-Make “role tagging” an optional ingest pipeline stage.
-
-At minimum, always distinguish between:
-
-source docs
-
-retrieval logs
-
-conversation memory
-
-4. Augmented Generation, not Raw Generation
-What this class is
-
-Instead of “throw context at LLM and say ‘answer this’”, you structure the reasoning process:
-
-Retrieve → reason over evidence → then answer.
-
-Sometimes with explicit intermediate steps (plans, chains, scratchpads).
-
-This reduces hallucinations and makes explanations more grounded.
-
-Relevance to Cake
-
-You want Cake to be more than “LangChain in Elixir.” Generation pipeline templates are a key differentiator:
-
-“Strict QA”
-
-“Summarize across docs”
-
-“Decision memo”
-
-All of them should be procedural templates for reasoning, not just prompts.
-
-4.1 Contextual Reasoning Chains
-
-What it is
-
-LLM explicitly generates intermediate reasoning steps over the retrieved evidence:
-
-Extract key facts from each chunk.
-
-Combine and reconcile facts.
-
-Produce final answer, citing sources.
-
-Pros
-
-Better faithfulness; easier to debug.
-
-Can be reused across queries as a pattern.
-
-Plays nicely with evaluation tools (you can evaluate intermediate steps).
-
-Cons
-
-More tokens and latency.
-
-If not carefully constrained, chain-of-thought can itself hallucinate.
-
-Mitigations
-
-Keep reasoning steps short and almost extractive (“List relevant facts from the context”).
-
-Hide chain-of-thought from end user while still logging it for internal eval.
-
-Put explicit instructions: “Only use facts from the context, quote them when possible.”
-
-Recent work & Cake angle
-
-Many recent RAG evaluations (FRAMES, ARES, etc.) implicitly assume multi-step reasoning patterns. 
-arXiv
-+1
-
-For Cake:
-
-Offer stock reasoning templates:
-
-“Evidence extraction”
-
-“Compare-and-contrast two policies”
-
-Cake can log intermediate reasoning for analytics (where did it go off the rails?).
-
-4.2 Retrieval-augmented Planning
-
-What it is
-
-LLM first plans the steps required to answer (including what to retrieve), then executes those steps, often with multiple retrieval iterations.
-
-Pros
-
-Crucial for multi-hop, complex workflows (e.g., “find all policies impacted by regulation X and summarize changes since 2022”).
-
-Lets you use different retrievers for different sub-queries.
-
-Cons
-
-More complicated architecture (agents, tools).
-
-Easy to over-engineer and blow your latency budget.
-
-Mitigations
-
-Restrict to two-stage or three-stage plans, not freeform agents.
-
-Use coarse “retrieval planner” that decides query decomposition and which index to query.
-
-Recent work & Cake angle
-
-LevelRAG again is relevant here: high-level searcher integrates multiple low-level ones. 
-arXiv
-+1
-
-Recent work on question decomposition + cross-encoder reranking also supports this multi-stage planned retrieval. 
-Hugging Face
-
-For Cake:
-
-Make “retrieval plan” an explicit data structure in the pipeline, not just hidden prompt text.
-
-Later: let advanced users program simple planners (in Elixir) that decide how to query based on question type.
-
-5. Guardrails Against LLM Bullshit
-What this class is
-
-Preventing or detecting hallucinations / unfaithful answers, especially in enterprise settings where “sounds plausible” but wrong can cost real money.
-
-Relevance to Cake
-
-If you want enterprise adoption, you must have a story around trust:
-
-Faithfulness checks
-
-Citation quality
-
-Monitoring hallucination rates over time
-
-5.1 Faithfulness Checks
-
-What it is
-
-Post-hoc or in-loop checks that the answer is supported by retrieved context:
-
-NLI-style models (entailment).
-
-LLM-as-a-judge scoring.
-
-Metamorphic tests (perturb inputs and see if answer behaves sanely).
-
-Pros
-
-Catch egregious hallucinations.
-
-Can output confidence scores or require human review.
-
-Cons
-
-Extra models & cost.
-
-Noisy judgments, especially cross-domain.
-
-Mitigations
-
-Use binary “safe/unsafe” thresholds instead of pretending you can get perfect calibration.
-
-Start with LLM-as-judge using simple faithful/unfaithful prompts.
-
-Only run heavy checks for high-risk tenants / queries.
-
-Recent work & Cake angle
-
-FaithJudge & hallucination leaderboards (Vectara 2025) – benchmarks faithfulness in RAG via LLM-as-judge. 
-ACL Anthology
-+2
-arXiv
-+2
-
-“Correctness is Not Faithfulness in RAG” (Wallat et al. 2025) – shows that just having a correct citation is not enough; citation must actually cause the answer. 
-arXiv
-+2
-ACM Digital Library
-+2
-
-MetaRAG (2025) – metamorphic testing framework for hallucinations in real-world RAG where gold labels are missing. 
-arXiv
-
-For Cake:
-
-Short-term: simple faithfulness scorer using LLM-as-judge and context.
-
-Long-term: integrate metamorphic tests as part of eval suite for tenants.
-
-5.2 “Show your citations” mode
-
-What it is
-
-Force the model to output inline citations tied to the retrieved chunks (e.g., [1], [2]) and then map to doc IDs / URLs.
-
-Pros
-
-Increases user trust.
-
-Enables automated evaluation of citation correctness / faithfulness.
-
-Encourages more grounded responses.
-
-Cons
-
-Models can mis-attribute citations.
-
-Formatting gets messy; UX must be handled by the app.
-
-Mitigations
-
-Post-process citations (like CiteFix) instead of trusting raw LLM output. 
-arXiv
-
-Evaluate citation correctness and fix or drop wrong ones.
-
-Recent work & Cake angle
-
-CiteFix (2025) – post-processing to improve citation accuracy with minimal cost. 
-arXiv
-
-RAGE & related work – use citation metrics to evaluate and fine-tune RAG. 
-ACL Anthology
-+2
-arXiv
-+2
-
-For Cake:
-
-Make citations mandatory for “factual QA” modes.
-
-Build a generic citation data model (chunk_id, char_span, doc_url).
-
-Allow tenant UI to style citations however they want.
-
-6. Domain Adaptation / Structured Retrieval
-What this class is
-
-Moving beyond “documents as bags of words” to use schemas, graphs, and domain structure:
-
-Tables, APIs, CRM objects, product hierarchies.
-
-Knowledge graphs.
-
-Relevance to Cake
-
-This is where you can start morphing from “RAG framework” to “RAG substrate for enterprise systems.” Enterprises already have schemas and graphs; you need to plug into them.
-
-6.1 Schema-Aware Retrieval
-
-What it is
-
-Use domain schemas (tables, JSON, code, API descriptions) to:
-
-Retrieve structured records, not just text.
-
-Embed both text and schema metadata.
-
-Let LLM reason over structured + unstructured evidence.
-
-Pros
-
-Better performance on tasks where values live in DBs or APIs.
-
-Ensures you’re reading latest data, not doc snapshots.
-
-Cons
-
-Needs connectors & schema mapping.
-
-Some LLMs struggle with complex structured prompts.
-
-Mitigations
-
-Do hybrid retrieval: structured queries (SQL/filters) + text search.
-
-Summarize structured outputs into LLM-friendly snippets.
-
-Recent work & Cake angle
-
-“Advancing RAG for Structured and Semi-Structured Data” (Cheerla et al., 2025) – hybrid retrieval using BM25, dense, and metadata-aware filtering for structured data. 
-arXiv
-
-For Cake:
-
-Define a schema ingestion interface: given a table or API, Cake knows how to:
-
-Build metadata-aware filters.
-
-Join structured results with text context.
-
-6.2 Graph-augmented Retrieval
-
-What it is
-
-Use a knowledge graph (or graph derived from text) to:
-
-Expand retrieval via neighbors.
-
-Organize context around entity/relationship paths.
-
-Guide multi-hop reasoning.
-
-Pros
-
-Better at coverage of related facts.
-
-More coherent long answers.
-
-Especially good in complex domains (biomed, legal, enterprise orgs).
-
-Cons
-
-Building/maintaining KGs is hard.
-
-Graph operations add latency.
-
-Graph must stay in sync with text.
-
-Mitigations
-
-Generate a lightweight KG from documents (entities + doc IDs).
-
-Link chunks to graph nodes (chunk linking). 
-Medium
-+1
-
-Use graph selectively for certain query types (multi-hop, cross-doc).
-
-Recent work & Cake angle
-
-KG²RAG (Zhu et al., 2025) – semantic retrieval → KG-guided expansion & organization → paragraphs for RAG. 
-ACL Anthology
-+2
-ACL Anthology
-+2
-
-GGR (Liu et al., 2025) – GNN-guided KG-RAG; uses GNNs to preserve key reasoning paths in graphs. 
-OpenReview
-
-GraphRAG / Graph-based enterprise posts – show big wins on cross-document reasoning. 
-ResearchGate
-+1
-
-For Cake:
-
-Don’t try to be “GraphRAG” v1, but:
-
-Provide hooks for tenants who already have graphs.
-
-Offer basic doc-derived graph: entities + doc IDs + links.
-
-6.3 Logit Bias for Domain Terms
-
-What it is
-
-Use logit bias / vocabulary steering so that the LLM:
-
-Prefers domain-specific terms present in context.
-
-Avoids generic replacements (“employee handbook” vs “staff manual”).
-
-Pros
-
-More consistent terminology.
-
-Reduces generic hallucinated phrasing.
-
-Useful for brand names, product names, internal acronyms.
-
-Cons
-
-Logit bias APIs are model-specific.
-
-Can cause weird outputs if misconfigured.
-
-Mitigations
-
-Apply bias only on a small curated term list per tenant.
-
-Keep bias magnitudes modest; test thoroughly.
-
-Recent work & Cake angle
-
-This is more practice than formal research; many enterprise RAG whitepapers mention vocabulary steering as a technique for brand-safe output. 
-Shaping the future together
-+1
-
-For Cake:
-
-Offer a “preferred vocabulary” config at tenant level.
-
-Later: auto-suggest vocabulary lists from their corpus.
-
-7. Conversational Memory / Localized Thread State
-What this class is
-
-Multi-turn RAG: keeping track of what’s been said, what’s retrieved before, and what the user cares about over time.
-
-Relevance to Cake
-
-You already think like a distributed systems guy. Treat a conversation as a stateful process, not a stateless Q/A. This is a natural place for Cake to overperform.
-
-7.1 Short-term memory embeddings (conversation-aware retrieval)
-
-What it is
-
-Embed conversation turns and use them:
-
-As additional retrieval signals (“the user and I have been talking about VPN, not HR”).
-
-To disambiguate pronouns and references.
-
-Pros
-
-Better contextual relevance.
-
-Reduces repeated clarifications.
-
-Cons
-
-Memory grows over time; retrieval over it can get expensive.
-
-Risk of retrieving outdated context (e.g., superseded answers).
-
-Mitigations
-
-Keep short-term memory bounded (last N turns plus summary).
-
-Summarize older turns.
-
-Recent work & Cake angle
-
-RAG memory surveys (2025) – review of RAG-driven memory architectures in conversational LLMs, emphasizing vector DB + RAG for context. 
-Vlaams Instituut voor de Zee
-+1
-
-Multi-turn RAG benchmarks like MTRAG/mtRAG (2025) – explicitly evaluate multi-turn retrieval and reasoning. 
-arXiv
-+2
-ResearchGate
-+2
-
-For Cake:
-
-Provide a built-in conversation memory store and retrieval hook, separate from the main KB.
-
-Let tenants tune:
-
-memory length
-
-summarization strategy
-
-7.2 Long-term memory (summaries, facts, commitments)
-
-What it is
-
-Persist distilled facts about the user or ongoing task:
-
-User prefs, company-specific decisions, “we agreed X last week”.
-
-Stored as structured objects or summarized notes.
-
-Pros
-
-Supports long-lived workflows and agents.
-
-Reduces re-asking the same questions.
-
-Cons
-
-Risk of storing wrong information.
-
-Can conflict with up-to-date KB content.
-
-Mitigations
-
-Include timestamps and confidence on stored facts.
-
-Periodically reconcile with authoritative sources.
-
-Recent work & Cake angle
-
-Long-term memory is covered in conversational memory surveys and in RAG evaluation for multi-turn tasks. 
-Vlaams Instituut voor de Zee
-+1
-
-For Cake:
-
-Offer a long-term memory interface:
-
-A simple key-value or fact-graph store.
-
-LLM helpers to update it cautiously.
-
-7.3 Multi-turn reference disambiguation
-
-What it is
-
-Resolve pronouns and shorthand:
-
-“That policy” → which one?
-
-“The second option you mentioned” → map back to specific chunk/doc.
-
-Pros
-
-Critical for enterprise conversational UX.
-
-Reduces misinterpretation.
-
-Cons
-
-Needs either:
-
-LLM-based resolution over prior turns
-
-or a graph of “mentions” and their bindings.
-
-Mitigations
-
-Use a small coreference resolver over recent turns.
-
-Use retrieval over conversation memory (“find which entity was just discussed”).
-
-Recent work & Cake angle
-
-Benchmarks like MTRAG focus on multi-turn QA where context tracking is essential. 
-arXiv
-+1
-
-For Cake:
-
-Make reference resolution an explicit step in the pipeline:
-
-Raw user query → rewritten, de-referenced query.
-
-8. Evaluation & Feedback Loops
-What this class is
-
-You cannot treat this as an afterthought. Real RAG deployment = constant measurement:
-
-Retrieval quality
-
-Generation faithfulness
-
-Drift over time
-
-Relevance to Cake
-
-A major differentiator for Cake can be first-class RAG evaluation tooling, instead of “you figure it out with LangSmith / random dashboards.”
-
-8.1 Synthetic Queries for Recall Testing
-
-What it is
-
-Use LLMs to generate synthetic:
-
-queries
-
-answers
-
-sometimes labels
-
-from your corpus; then evaluate retrieval and generation on these. 
-Modulai
-+3
-ACL Anthology
-+3
-ACM Digital Library
-+3
-
-Pros
-
-Cheap way to build eval sets without human labeling.
-
-Lets you compare chunking/retrieval configs quickly.
-
-Enables automated acceptance checks before deploying changes.
-
-Cons
-
-Synthetic queries may not match real user distribution.
-
-LLM-generated answers can be wrong, polluting labels.
-
-Mitigations
-
-Mix in small human-validated subset.
-
-Use LLM-as-judge for scoring, not as ground truth.
-
-Recent work & Cake angle
-
-ARES (Saad-Falcon et al., 2024) – automated RAG evaluation using synthetic queries and LLM judges. 
-ACL Anthology
-
-FRAMES (2024) – unified dataset to evaluate factuality, retrieval, and reasoning in RAG. 
-arXiv
-
-Synthetic test collections for IR (2024) – fully synthetic IR benchmarks with LLMs. 
-ACM Digital Library
-
-For Cake:
-
-Build a “synthetic eval kit”:
-
-Given a corpus, auto-generate 100–500 synthetic queries + answers.
-
-Run them through different Cake pipelines.
-
-Output recall/precision/faithfulness metrics.
-
-8.2 “Drift detection” for content updates
-
-What it is
-
-Monitor changes over time:
-
-Data drift – new docs, updated policies.
-
-Concept drift – meaning of queries changes.
-
-Model drift – new model versions behave differently.
-
-Pros
-
-Prevents silent degradation.
-
-Gives you a story for enterprises: “we know when it breaks.”
-
-Cons
-
-Nontrivial to implement; metrics can be fuzzy.
-
-Requires historical logs, not just snapshots.
-
-Mitigations
-
-Track simple KPIs:
-
-context recall
-
-answer faithfulness
-
-user feedback rates.
-
-Alert on significant deltas.
-
-Recent work & Cake angle
-
-Industry resources on retrieval drift monitoring and concept drift adaptation. 
-ApX Machine Learning
-+2
-Rohan's Bytes
-+2
-
-RAG evaluation pieces emphasize the need for continuous monitoring in production. 
-morphik.ai
-+2
-Braintrust
-+2
-
-For Cake:
-
-Incorporate drift dashboards at the framework level:
-
-By corpus
-
-By tenant
-
-Before/after model version changes
-
-Recommendations for Cake
-
-Here’s the pragmatic bit: what to do now, what to tweak in the MVP, and where you can actually get edge.
-
-A. Immediate Priorities (next MVP iterations)
-
-Lock in Retrieval as a configurable pipeline
-
-Implement hybrid retrieval in OpenSearch:
-
-BM25 + dense or neural sparse + dense, with tunable weights. 
-Amazon Web Services, Inc.
-+1
-
-Add a simple reranker:
-
-Start with a small cross-encoder on CPU or cheap GPU.
-
-Add optional query expansion:
-
-Start with HyDE-style “generate hypothetical answer → embed.” 
-ACL Anthology
-+1
-
-Chunking v1.5 – Metadata-aware, with overlap
-
-Implement metadata-aware semantic chunking using headings / sections where available. 
-Chroma Research
-+2
-Databricks Community
-+2
-
-Support configurable overlap per index.
-
-Store basic metadata: doc_id, section_title, page, etc.
-
-Context Builder abstraction
-
-Extract from your current pipeline a formal ContextBuilder:
-
-Dedup hits.
-
-Group by document.
-
-Attach metadata/roles.
-
-Provide two strategies:
-
-Simple “top-k raw chunks”
-
-“Grouped by document” with basic summarization.
-
-Citations and Logging
-
-Add a mandatory citation mode for factual QA paths.
-
-Log:
-
-retrieved chunk IDs
-
-citations used
-
-faithfulness scores (basic LLM-as-judge)
-
-Basic Evaluation Harness
-
-Implement a tiny ARES-inspired eval workflow:
-
-Synthetic queries from corpus.
-
-LLM-as-judge scoring of answer relevance / faithfulness. 
-ACL Anthology
-+2
-Modulai
-+2
-
-This is enough to make Cake feel like a serious framework, not “DIY LangChain.”
-
-B. Changes to the MVP Design
-
-None of this requires a total rewrite, but a few structural decisions matter now:
-
-Make pipelines first-class
-
-Represent retrieval/generation as a structured Elixir pipeline:
-
-query_normalize -> planner (optional) -> retriever(s) -> reranker -> context_builder -> generator -> guardrails
-
-Store configs in a domain-agnostic YAML/JSON so tenants can define pipelines declaratively.
-
-Design the document schema for multi-representation
-
-Even if you don’t fully exploit it yet, define your OpenSearch schema to allow:
-
-multiple vector fields (raw, summary, entities)
-
-rich metadata
-
-This avoids migration pain later. 
-baobabtech.ai
-+1
-
-Split memory from KB
-
-Keep conversational memory in a separate index / store from the main corpus.
-
-Define a clean API between:
-
-conversation-memory retrieval
-
-corpus retrieval
-
-C. Most Relevant to Scaling Cake
-
-When you start doing high-touch implementations like Databricks/Palantir, what will matter most:
-
-Configurable Retrieval Recipes
-
-Each customer gets a slightly different:
-
-hybrid weights
-
-chunking strategy
-
-reranking depth
-
-You want Cake to let you tweak this in config, not code.
-
-Evaluation & Monitoring Built In
-
-Cake ships with:
-
-synthetic eval harness
-
-faithfulness scoring
-
-drift dashboard hooks
-
-This lets you say to enterprises: “We don’t just build your RAG, we monitor and tune it over time.” 
-Medium
-+1
-
-Hooks for Structure (Schemas, Graphs)
-
-You don’t need full KG²RAG day one, but:
-
-Have the extension points for graph-based retrieval.
-
-Allow ingestion from SQL/NoSQL tables with domain-aware filters.
-
-D. Potential Competitive Advantages You Could Seize Early
-
-These are the “this actually looks novel” angles that align with how your brain works.
-
-Multi-Representation Chunking as a First-Class Feature
-
-Most tools still treat chunks as a single embedding.
-
-Cake can:
-
-Define a multi-vector document schema
-
-Provide stock pipelines for combining them
-
-This plays to your strength (schema design + OpenSearch familiarity). 
-baobabtech.ai
-+1
-
-Built-in Chunking Evaluation Lab
-
-Almost no one productizes Chroma-style chunking eval as a first-class feature. 
-Chroma Research
-+1
-
-Cake could let a customer:
-
-Upload corpus
-
-Try 3–4 chunking configs
-
-See side-by-side metrics and example queries
-
-Conversation-Aware Enterprise RAG
-
-Many products still treat each query as stateless.
-
-You can bake in:
-
-short-term memory embeddings
-
-basic long-term memory
-
-multi-turn evaluation (MTRAG-style) 
-arXiv
-+2
-IBM Research
-+2
-
-That’s a nice wedge: “Cake is for ongoing knowledge work, not just single questions.”
-
-Evaluation as Part of the Core Story
-
-Use ARES/FRAMES ideas to make evaluation part of the standard Cake deployment. 
-ACL Anthology
-+2
-arXiv
-+2
-
-You pitch: “We help you measure and not just build RAG.”
-
-Reality Check / Obstacles
-
-Just to keep it honest:
-
-Risk 1 – Overengineering early
-You absolutely have the brain to chase LevelRAG/GG2RAG graphs and Gaussian QE spaces. The danger is trying to build the “RAG research lab of your dreams” instead of a sellable v1.
-
-Mitigation:
-
-Ship Hybrid + Rerank + Semantic chunking + Citations + Basic eval first.
-
-Treat everything else as “Phase 2 modules.”
-
-Risk 2 – Self-punishment loops via perfectionism
-If you catch yourself thinking “it’s not worth launching unless it’s state-of-the-art across all eight dimensions,” that’s the sabotage talking, not the engineer. A lot of very mid RAG SaaS is making money right now.
-
-Mitigation:
-
-Define a hard MVP threshold:
-
-Hybrid retrieval
-
-Semantic chunking
-
-Citations
-
-Basic synthetic eval
-
-Anything beyond that is explicitly backlog, not “secret requirement.”
-Document Title
-
+- **Over-engineering early.** The research directions above (LevelRAG-style planning, graph retrieval, advanced query expansion) are tempting, but the priority is a sellable v1, not a research platform. *Mitigation:* ship hybrid retrieval, re-ranking, semantic chunking, citations, and basic evaluation first; everything else is explicitly Phase 2.
+- **Scope creep through perfectionism.** The MVP does not need to be state-of-the-art across all eight areas to be viable. *Mitigation:* define a hard MVP threshold — hybrid retrieval, semantic chunking, citations, basic synthetic evaluation — and treat anything beyond it as explicit backlog rather than an implicit requirement.

--- a/feature_roadmap.md
+++ b/feature_roadmap.md
@@ -1,712 +1,155 @@
 # Cake Feature Roadmap: RAG Enhancements
 
-This document surveys the RAG techniques most relevant to Cake's evolution, organised into eight capability areas. Each subsection describes the technique, its trade-offs, mitigations for the main risks, relevant recent work, and the direction it suggests for Cake. The closing [Recommendations](#recommendations) section distils the survey into concrete priorities.
+A checklist of RAG capabilities for Cake, organised into eight capability areas plus cross-cutting design groundwork. Each area opens with a line of context and links to the relevant literature; the boxes are the roadmap.
+
+**How to read this.** Checked items exist on `master`, verified against the commit history and current code as of 2026-08-13 (through #241); each cites its module and, where applicable, the PR that landed it. Unchecked items are not yet built. Items marked **(priority)** form the MVP threshold plus the immediate next steps; anything beyond them is explicitly backlog, not an implicit launch requirement. Ideas too open-ended to be checked off live in [Reach Goals](#reach-goals) at the end.
 
 ## Contents
 
 - [1. Retrieval](#1-retrieval)
-  - [1.1 Hybrid Search](#11-hybrid-search)
-  - [1.2 Re-ranking Pipelines](#12-re-ranking-pipelines)
-  - [1.3 Query Expansion](#13-query-expansion)
 - [2. Chunking](#2-chunking)
-  - [2.1 Semantic Chunking](#21-semantic-chunking)
-  - [2.2 Overlapping Windows](#22-overlapping-windows)
-  - [2.3 Multi-Representation Chunks](#23-multi-representation-chunks)
 - [3. Context Assembly](#3-context-assembly)
-  - [3.1 Deduplication and Consolidation](#31-deduplication-and-consolidation)
-  - [3.2 Section-Aware Assembly](#32-section-aware-assembly)
-  - [3.3 Role-Annotated Context](#33-role-annotated-context)
 - [4. Augmented Generation](#4-augmented-generation)
-  - [4.1 Contextual Reasoning Chains](#41-contextual-reasoning-chains)
-  - [4.2 Retrieval-Augmented Planning](#42-retrieval-augmented-planning)
 - [5. Guardrails and Faithfulness](#5-guardrails-and-faithfulness)
-  - [5.1 Faithfulness Checks](#51-faithfulness-checks)
-  - [5.2 Citation Mode](#52-citation-mode)
 - [6. Structured and Domain-Aware Retrieval](#6-structured-and-domain-aware-retrieval)
-  - [6.1 Schema-Aware Retrieval](#61-schema-aware-retrieval)
-  - [6.2 Graph-Augmented Retrieval](#62-graph-augmented-retrieval)
-  - [6.3 Vocabulary Steering](#63-vocabulary-steering)
 - [7. Conversational Memory](#7-conversational-memory)
-  - [7.1 Conversation-Aware Retrieval](#71-conversation-aware-retrieval)
-  - [7.2 Long-Term Memory](#72-long-term-memory)
-  - [7.3 Multi-Turn Reference Disambiguation](#73-multi-turn-reference-disambiguation)
 - [8. Evaluation and Feedback Loops](#8-evaluation-and-feedback-loops)
-  - [8.1 Synthetic Query Evaluation](#81-synthetic-query-evaluation)
-  - [8.2 Drift Detection](#82-drift-detection)
-- [Recommendations](#recommendations)
-  - [A. Immediate Priorities](#a-immediate-priorities)
-  - [B. MVP Design Changes](#b-mvp-design-changes)
-  - [C. Scaling Considerations](#c-scaling-considerations)
-  - [D. Early Differentiators](#d-early-differentiators)
-  - [Risks](#risks)
+- [Design Groundwork](#design-groundwork)
+- [Reach Goals](#reach-goals)
 
 ---
 
 ## 1. Retrieval
 
-Retrieval determines which candidate chunks are selected from the corpus before the LLM sees anything. Weak retrieval cannot be compensated for downstream; in production RAG systems it typically accounts for the majority of answer quality. Hybrid search, re-ranking, and query expansion are three levers for improving recall and precision beyond cosine similarity on a single embedding.
+How candidate chunks are selected before the LLM sees anything; weak retrieval cannot be compensated for downstream. Cake treats retrieval as configurable, composable, observable pipeline stages.
 
-**Relevance to Cake.** Cake is a framework, not a single application, so the retrieval layer must be:
+References: [Wang et al. 2024](https://arxiv.org/abs/2407.01219) (best-practices study; hybrid + HyDE), [LevelRAG](https://arxiv.org/abs/2502.18139) (decomposition/planning), [AWS OpenSearch sparse+dense hybrid](https://aws.amazon.com/blogs/big-data/integrate-sparse-and-dense-vectors-to-enhance-knowledge-retrieval-in-rag-using-amazon-opensearch-service), [KG²RAG](https://arxiv.org/abs/2502.06864) (graph-guided re-ranking), [Verma et al. 2025](https://arxiv.org/abs/2507.05577) (re-ranker ensembles), [Pan et al. 2025](https://www.mdpi.com/2079-9292/14/9/1744) (Gaussian-kernel expansion), [Zhang et al. 2024](https://aclanthology.org/2024.findings-emnlp.103/) (query-expansion best practices).
 
-- **Configurable** — per-tenant and per-domain retrieval recipes.
-- **Composable** — query → retrieve → re-rank → post-filter.
-- **Observable** — it should be possible to see why a given query failed.
-
-Hybrid search, re-ranking, and query expansion should all be first-class pipeline stages that Cake exposes.
-
-### 1.1 Hybrid Search
-
-**What it is.** Combine sparse retrieval (BM25 or neural sparse) with dense (embedding-based) retrieval into one ranked list, either via score fusion (e.g. a weighted sum) or a multi-stage arrangement (BM25 followed by a dense filter, or vice versa). Hybrid retrieval is now widely regarded as the best default for RAG.
-
-**Benefits**
-
-- Substantially more robust across query types: sparse handles rare terms, identifiers, and codes; dense handles paraphrase and fuzzy language.
-- Well suited to enterprise knowledge bases that mix jargon with natural language.
-- Maps directly onto OpenSearch, which provides BM25, dense, and neural sparse retrieval out of the box.
-
-**Trade-offs**
-
-- Score fusion is sensitive to how sparse and dense scores are weighted.
-- Multiple retrievers add latency and infrastructure complexity.
-- Untuned BM25 can over-emphasise long documents or noisy fields.
-
-**Mitigations**
-
-- Learn fusion weights per index or per tenant (grid search or a small regression model suffices).
-- Normalise scores per retriever (z-score or min–max).
-- Use metadata filters and field-specific boosts (e.g. title over body) to keep BM25 well behaved.
-
-**Relevant work**
-
-- Wang et al., 2024, [*Searching for Best Practices in Retrieval-Augmented Generation*](https://arxiv.org/abs/2407.01219) (EMNLP 2024) — a broad empirical study of RAG configurations (retrievers, chunking, re-ranking) finding that hybrid search combined with HyDE-style query rewriting is often the best accuracy/latency trade-off. For Cake, their recommended "hybrid + HyDE" recipe is a strong candidate for the default retrieval preset.
-- Zhang et al., 2025, [*LevelRAG: Enhancing Retrieval-Augmented Generation with Multi-hop Logic Planning over Rewriting Augmented Searchers*](https://arxiv.org/abs/2502.18139) — decomposes complex queries into atomic sub-queries routed across multiple retrievers, independent of retriever-specific optimisation. Aligns with a "structured retrieval" preset combining graph, dense, and re-ranking stages.
-- AWS, 2024, [*Integrate sparse and dense vectors to enhance knowledge retrieval in RAG using Amazon OpenSearch Service*](https://aws.amazon.com/blogs/big-data/integrate-sparse-and-dense-vectors-to-enhance-knowledge-retrieval-in-rag-using-amazon-opensearch-service) — demonstrates neural sparse + dense hybrids on OpenSearch, directly applicable to Cake's stack. Suggests shipping a standard OpenSearch hybrid retriever module with tunable weights and field boosts, plus configuration templates for common corpus shapes (documentation, code, FAQ-heavy knowledge bases).
-- Domain-specific hybrid QA studies (2024–2025) report that dense + BM25 hybrids significantly improve question answering in specialised domains.
-
-**Open questions**
-
-- Learn per-tenant fusion weights from minimal feedback signals (clicks, explicit ratings).
-- Evaluate whether OpenSearch neural sparse + dense outperforms classic BM25 + dense for Cake's target enterprise domains, and publish the results as a retrieval study.
-
-### 1.2 Re-ranking Pipelines
-
-**What it is.** Two-stage retrieval: first gather a large candidate pool (top-50 to top-100 chunks), then score each candidate more precisely with a cross-encoder or an LLM acting as re-ranker, producing a much stronger top-5.
-
-**Benefits**
-
-- Large quality improvement, especially in noisy knowledge bases with duplicate documents and boilerplate.
-- Keeps recall high while controlling the LLM context size.
-- Valuable in high-stakes domains (compliance, finance, medical).
-
-**Trade-offs**
-
-- Added latency from scoring 50–100 candidates with a heavier model.
-- Additional serving infrastructure (GPU/CPU capacity, batching, caching).
-- Re-ranking cannot compensate for poor first-stage retrieval.
-
-**Mitigations**
-
-- Use efficient cross-encoders (e.g. MiniLM, MPNet) and batch requests across tenants.
-- Cache re-ranker scores for repeated queries and canonical question templates.
-- Adapt candidate pool size to the query (e.g. k=30 for short queries, k=100 for multi-hop).
-
-**Relevant work**
-
-- Zhu et al., 2025, [*Knowledge Graph-Guided Retrieval Augmented Generation* (KG²RAG)](https://arxiv.org/abs/2502.06864) (NAACL 2025) — combines semantic retrieval with knowledge-graph-guided organisation and cross-encoder re-ranking. Points toward graph-aware re-rankers as an advanced option for tenants with graph data.
-- Verma et al., 2025, [*Beyond Retrieval: Ensembling Cross-Encoders and GPT Rerankers with LLMs for Biomedical QA*](https://arxiv.org/abs/2507.05577) — ensembles cross-encoders with LLM re-rankers for biomedical QA. Motivates pluggable re-ranker backends in Cake ("lightweight cross-encoder", "LLM re-ranker", "ensemble"), configurable per tenant.
-- Industry analyses (Pinecone, Databricks, and others) consistently identify re-ranking as one of the simplest high-impact additions to a RAG stack.
-
-**Open questions**
-
-- Re-rank chunk *groups* (all chunks from the same document or section) rather than individual chunks.
-- Multi-objective re-ranking for enterprise use: relevance combined with recency and access control.
-
-### 1.3 Query Expansion
-
-**What it is.** Automatically expand or rewrite a user query into richer representations: paraphrases, related terms, or synthetic "ideal answers" that are then used for retrieval. Includes HyDE-style approaches (generate a hypothetical answer and embed it) and LLM-based expansion variants.
-
-**Benefits**
-
-- Compensates for short or vague queries ("VPN broken", "hr policy maternity").
-- Bridges lexical gaps: synonyms, abbreviations, multilingual phrasing.
-- Particularly effective in combination with hybrid retrieval.
-
-**Trade-offs**
-
-- Expansions can drift, introducing irrelevant concepts.
-- Generating many expansions per query is computationally expensive.
-- Can reduce precision by pulling in tangential documents.
-
-**Mitigations**
-
-- Limit expansion to two or three short variants.
-- Use retrieval feedback: discard expansions whose retrieved sets diverge from the others.
-- Keep a no-expansion path and A/B compare against it.
-
-**Relevant work**
-
-- Zhang et al., 2025, [*LevelRAG*](https://arxiv.org/abs/2502.18139) — treats query rewriting as a general planning layer decoupled from any single retriever. For Cake, this suggests a "retrieval planner" abstraction: one module performs query decomposition and expansion, then routes sub-queries across hybrid retrievers.
-- Pan et al., 2025, [*LLM-Based Query Expansion with Gaussian Kernel Semantic Enhancement for Dense Retrieval*](https://www.mdpi.com/2079-9292/14/9/1744) (Electronics 14(9)) — query expansion using a Gaussian-kernel semantic space to refine multiple expansion vectors for dense retrieval. A future research direction rather than an MVP feature; a simplified multi-embedding expansion mode could follow later.
-- Zhang et al., 2024, [*Exploring the Best Practices of Query Expansion with Large Language Models*](https://aclanthology.org/2024.findings-emnlp.103/) (Findings of EMNLP 2024) — systematic study showing that query expansion helps weaker retrievers most; strong dense models already perform some semantic expansion implicitly. For Cake, expansion should be optional and primarily valuable for tenants using cheaper embedding models.
-
-**Open questions**
-
-- Evaluate per tenant whether query expansion helps, using small offline tests.
-- Investigate retrieval-grounded expansion in the style of the [RFG framework](https://www.scitepress.org/Link.aspx?doi=10.5220/0013836900004000) (Vega Centeno Olivera et al., KDIR 2025), where expansions are grounded in feedback from an initial retrieval and re-scored.
-
----
+- [x] Keyword, vector, and hybrid search modes, with hybrid as the default (`Cake.Search`; #31, #54)
+- [x] Configurable hybrid weighting and per-field caret boosts (`Search.Query` `:boost`, `Cake.GDS.search_fields/0`)
+- [x] Score normalisation and combination across retrieval signals (`Search.normalize_and_combine/1`, `score_results/2`)
+- [x] Pluggable search-backend behaviour with OpenSearch implementation, Mox-substitutable (`Search.Backend`; #192)
+- [x] LLM query decomposition into atomic sub-questions, as an opt-in collaborator (`Cake.Decomposition` behaviour + `.LLM` implementation; #235–#237)
+- [x] Concurrent sub-question search fan-out with bounded concurrency and timeouts (#241)
+- [ ] **(priority)** Cross-encoder re-ranking stage over a widened candidate pool (top-50/100 → top-k)
+- [ ] **(priority)** HyDE-style query expansion (generate hypothetical answer → embed), optional per query, with a no-expansion A/B path
+- [ ] Re-ranker score caching for repeated or canonical queries
+- [ ] Adaptive candidate-pool sizing by query type (short vs. multi-hop)
+- [ ] Retrieval configuration presets per corpus shape (documentation KB, code, FAQ-heavy)
+- [ ] Evaluate OpenSearch neural sparse + dense against BM25 + dense on target corpora
 
 ## 2. Chunking
 
-Chunking determines how raw documents are divided into embedding units. Recent literature indicates that chunking strategy alone can move recall by five to ten percentage points on realistic RAG tasks.
+How raw documents are divided into embedding units; chunking strategy alone can move recall by five to ten points. Chunkers should be pluggable strategies with per-domain presets.
 
-**Relevance to Cake.** As a framework, Cake should treat chunkers as pluggable strategies with:
+References: [Smith and Troynikov (Chroma) 2024](https://research.trychroma.com/evaluating-chunking) (chunking evaluation), [Merola and Singh 2025](https://arxiv.org/abs/2504.19754) (late chunking vs. contextual retrieval), [Tripathi et al. 2025](https://arxiv.org/abs/2506.16035) (vision-guided chunking for PDFs).
 
-- Sensible defaults (recursive character, semantic, metadata-aware).
-- Domain-specific presets (PDF reports vs. tickets vs. code).
-- Evaluation harnesses, so tenants can measure how chunking changes retrieval.
-
-### 2.1 Semantic Chunking
-
-**What it is.** Segment documents using structure and semantics — headings, paragraphs, list boundaries, or LLM-based segmenters — rather than fixed-size windows.
-
-**Benefits**
-
-- Chunks are more likely to be self-contained enough to answer a question.
-- Fewer concepts cut mid-thought at chunk boundaries.
-- Better suited to long enterprise documents (policies, SOPs, contracts).
-
-**Trade-offs**
-
-- Requires more sophisticated ingestion and robust parsing.
-- Poorly structured PDF/HTML can defeat structural cues.
-- LLM-based segmentation adds latency and cost.
-
-**Mitigations**
-
-- Apply inexpensive deterministic rules first (headings, sections); fall back to LLM chunking only for unstructured documents.
-- Cache LLM and multimodal chunking results aggressively.
-- Track chunk usefulness over time and refine heuristics accordingly.
-
-**Relevant work**
-
-- Smith and Troynikov (Chroma), 2024, [*Evaluating Chunking Strategies for Retrieval*](https://research.trychroma.com/evaluating-chunking) — rigorous comparison of chunking strategies using recall, precision, and IoU-style metrics; semantic and metadata-aware chunkers outperform naive ones, with open-source tooling. Cake could productise a comparable chunking evaluation lab — something few frameworks offer.
-- Merola and Singh, 2025, [*Reconstructing Context: Evaluating Advanced Chunking Strategies for Retrieval-Augmented Generation*](https://arxiv.org/abs/2504.19754) — compares late chunking with contextual retrieval; contextual retrieval preserves coherence at higher cost, late chunking is efficient but loses detail. Suggests a "contextual retrieval mode" as an advanced option for high-value tenants.
-- Tripathi et al., 2025, [*Vision-Guided Chunking Is All You Need: Enhancing RAG with Multimodal Document Understanding*](https://arxiv.org/abs/2506.16035) — uses multimodal models to handle tables, figures, and cross-page structure. Relevant for enterprises with heavy reporting output.
-
-### 2.2 Overlapping Windows
-
-**What it is.** Allow adjacent chunks to overlap so boundary regions appear in multiple chunks (e.g. 1,000-token chunks with 200-token overlap).
-
-**Benefits**
-
-- Reduces errors caused by a crucial sentence falling on a chunk boundary.
-- Important for code, protocols, and step-wise procedures.
-- Makes retrieval more tolerant of segmentation choices.
-
-**Trade-offs**
-
-- Increases index size and ingestion cost.
-- Amplifies duplicates, adding retrieval redundancy.
-- More noise for downstream stages if the re-ranker or generator cannot filter it.
-
-**Mitigations**
-
-- Tune overlap per document type: larger for code, smaller for FAQs.
-- Pair with deduplication at retrieval time, merging overlapping hits.
-- Group related chunks during context assembly.
-
-**Relevant work.** Recent chunking studies treat overlap as a tunable hyperparameter and find moderate overlap (10–30%) generally beneficial, with diminishing returns beyond that. For Cake: support per-index overlap configuration and ship profiles such as "long-form policy documents" (moderate overlap) and "code/API documentation" (higher overlap).
-
-### 2.3 Multi-Representation Chunks
-
-**What it is.** Store multiple embeddings per chunk, each capturing a different view: raw text, summary, extracted entities, or separate title and body embeddings. Also known as multi-vector embeddings.
-
-**Benefits**
-
-- Improves retrieval for entity-heavy queries (entity embedding) and conceptual queries (summary embedding).
-- Different views can be weighted at query time.
-
-**Trade-offs**
-
-- Higher storage requirements.
-- More complex retrieval logic.
-- Harder index maintenance, with multiple vector fields per chunk.
-
-**Mitigations**
-
-- Start with two representations: the full chunk plus a summary or entity view.
-- Use OpenSearch's support for multiple vector fields per document.
-- Apply simple fusion rules per query type.
-
-**Relevant work.** Industry reports show multi-vector retrieval yielding significant improvements on heterogeneous data, and RAG evolution reviews note that token-level and multi-vector representations are increasingly common for complex document structures. For Cake this is a genuine differentiator: offer a multi-representation schema as part of the ingestion configuration and let advanced users plug in their own summarisers and entity extractors.
-
-**Open questions**
-
-- Which combinations of representations give the best returns for enterprise knowledge bases (e.g. title + summary vs. summary + entities)?
-- The results could support a short publication: *Multi-Representation Chunking for Enterprise RAG with OpenSearch*.
-
----
+- [x] Chunk-level metadata: page number, section title, chunk index, word/char counts (`Cake.Books.Chunk` schema; #62)
+- [x] Structure-derived retrieval units for documentation: one retrievable per documentation entry (`ParsedDocument`; #27)
+- [ ] **(priority)** Semantic chunking for books using headings/paragraph/list cues — current PDF chunking is one chunk per page (`Cake.Books.Pdf.Pipeline`)
+- [ ] **(priority)** Configurable overlapping windows per index
+- [ ] Chunking profiles per document type (long-form policy vs. code/API docs)
+- [ ] LLM-fallback chunker for unstructured documents, with aggressive caching
+- [ ] Multi-representation chunks: multiple embeddings per chunk (raw text + summary/entities) with query-time weighting
 
 ## 3. Context Assembly
 
-Given a set of retrieved chunks, context assembly decides what is sent to the LLM and in what form: removing duplicates, grouping related chunks, and annotating their roles. This stage has a large effect on hallucination rates and coherence, particularly with long contexts.
+Deciding what reaches the LLM and in what form: deduplication, grouping, and labelling of retrieved chunks. Most frameworks treat this as an afterthought; Cake makes it a pipeline stage.
 
-**Relevance to Cake.** Most frameworks treat context assembly as an afterthought. Cake can make it a first-class pipeline stage: a context builder that is pluggable per tenant, with built-in strategies ranging from simple top-k through grouping by document, section, or role.
-
-### 3.1 Deduplication and Consolidation
-
-**What it is.** *Deduplication* removes near-identical chunks (identical text or high cosine similarity). *Consolidation* merges related chunks into concise summaries before they reach the LLM.
-
-**Benefits**
-
-- Less wasted context budget.
-- Fewer conflicting statements in context.
-- More grounded, concise answers.
-
-**Trade-offs**
-
-- Summarisation can itself hallucinate or drop critical detail.
-- Consolidation adds latency.
-- Citation tracking becomes more involved.
-
-**Mitigations**
-
-- Prefer extractive summaries (selecting key sentences) over abstractive rewrites.
-- Restrict consolidation to chunks from the same document or section.
-- Retain links to all source chunk IDs for citation purposes.
-
-**Relevant work.** RAG best-practice guides consistently note that passing the top-N chunks verbatim is suboptimal; several employ post-retrieval clustering plus summarisation. For Cake: implement a document-level context builder (retrieve → cluster by document → summarise per document), and add a strict mode that uses only exact, unconsolidated chunks for high-risk queries.
-
-### 3.2 Section-Aware Assembly
-
-**What it is.** Group chunks by document section (e.g. "Section 3: Billing Disputes") or by conceptual role (background, constraints, examples), and present that structure to the LLM.
-
-**Benefits**
-
-- Labelled groupings reduce context confusion.
-- Effective for multi-document answers ("Policy A says X; Policy B says Y").
-- Supports multi-hop reasoning by making each chunk's role explicit.
-
-**Trade-offs**
-
-- Depends on good metadata at ingestion (headings, hierarchy).
-- Not all corpora have clean structure (ticket logs, chat transcripts).
-- Prompt construction becomes more complex.
-
-**Mitigations**
-
-- For unstructured data, use simple heuristics (source, date, document type) as pseudo-sections.
-- Provide default prompt scaffolds for sectioned context.
-
-**Relevant work.** Community and enterprise guidance shows that sectioned context improves RAG QA quality. For Cake: include a section-aware context template as a core feature, and expose structured prompts where context is passed as, for example, `{definitions: [], procedures: [], examples: []}`.
-
-### 3.3 Role-Annotated Context
-
-**What it is.** Assign roles to chunks — facts, definitions, constraints, examples, user history — and instruct the LLM how to use them (e.g. "prioritise constraints over examples when they conflict").
-
-**Benefits**
-
-- More deterministic, policy-compliant answers.
-- Predictable conflict handling (policy vs. example).
-- A good fit for enterprise compliance and SOP workflows.
-
-**Trade-offs**
-
-- Requires chunk classification, whether manual or model-based.
-- More complex prompts and context construction.
-
-**Mitigations**
-
-- Start with simple roles derived from metadata or heuristics (title, path).
-- Add optional LLM-based role classification as an offline pipeline.
-
-**Relevant work.** Role-annotated context is an emerging pattern in enterprise RAG literature, motivated by auditability and consistency, rather than the subject of dedicated academic study. For Cake: make role tagging an optional ingestion stage, and at minimum always distinguish source documents, retrieval logs, and conversation memory.
-
----
+- [x] Relevance-floor and chunk-ceiling filtering with dense 1..N prompt indices (`Prompt.prepare_context/2`)
+- [x] Neighbor expansion around direct hits, with merged ranges and per-book deduplication (`Books.Retrieval`, `Cake.GDS.expand_with_neighbors/2`)
+- [x] Cross-sub-question result deduplication when merging decomposed searches into one context (#239)
+- [x] Struct-rendered prompt context via protocol, per retrievable type (`Cake.Promptable`)
+- [ ] **(priority)** Formal `ContextBuilder` stage: near-duplicate removal by similarity, grouping by document, metadata/role attachment
+- [ ] Per-document consolidation via extractive summarisation, with citation back-links to source chunks, plus a strict mode (exact chunks only) for high-risk queries
+- [ ] Section-aware assembly: labelled buckets (definitions/procedures/examples) in the prompt scaffold
+- [ ] Role annotation of chunks (facts, constraints, examples, history) with conflict-priority instructions
 
 ## 4. Augmented Generation
 
-Rather than passing context to the LLM with a bare "answer this", augmented generation structures the reasoning process: retrieve, reason over the evidence, then answer — sometimes with explicit intermediate artifacts (plans, chains, scratchpads). This reduces hallucination and produces better-grounded explanations.
+Structuring the reasoning process — retrieve, reason over evidence, then answer — rather than raw prompt-and-pray. Generation pipeline templates are procedural, not just prompts.
 
-**Relevance to Cake.** For Cake to be more than "LangChain in Elixir", generation pipeline templates are a key differentiator — "strict QA", "summarise across documents", "decision memo" — each a procedural template for reasoning, not merely a prompt.
+References: [Plan\*RAG](https://arxiv.org/abs/2410.20753) (plan-then-retrieve), [LevelRAG](https://arxiv.org/abs/2502.18139).
 
-### 4.1 Contextual Reasoning Chains
-
-**What it is.** The LLM explicitly generates intermediate reasoning steps over the retrieved evidence: extract key facts from each chunk, combine and reconcile them, then produce a final answer with citations.
-
-**Benefits**
-
-- Better faithfulness and easier debugging.
-- Reasoning patterns can be reused across queries.
-- Intermediate steps are themselves evaluable, which suits automated evaluation tooling.
-
-**Trade-offs**
-
-- More tokens and higher latency.
-- Unconstrained chain-of-thought can introduce its own hallucinations.
-
-**Mitigations**
-
-- Keep reasoning steps short and largely extractive ("list the relevant facts from the context").
-- Hide intermediate reasoning from end users while logging it for internal evaluation.
-- Instruct explicitly: use only facts from the context, quoting where possible.
-
-**Relevant work.** Recent RAG evaluation efforts (FRAMES, ARES, and others) implicitly assume multi-step reasoning patterns. For Cake: offer stock reasoning templates such as "evidence extraction" and "compare and contrast two policies", and log intermediate reasoning for analytics on where answers go wrong.
-
-### 4.2 Retrieval-Augmented Planning
-
-**What it is.** The LLM first plans the steps required to answer — including what to retrieve — then executes the plan, often over multiple retrieval iterations.
-
-**Benefits**
-
-- Essential for multi-hop and complex workflows (e.g. "find all policies affected by regulation X and summarise the changes since 2022").
-- Different retrievers can serve different sub-queries.
-
-**Trade-offs**
-
-- More complex architecture (agents, tools).
-- Easy to over-engineer, with significant latency cost.
-
-**Mitigations**
-
-- Restrict plans to two or three stages rather than free-form agent loops.
-- Use a coarse retrieval planner that decides query decomposition and index routing.
-
-**Relevant work**
-
-- Zhang et al., 2025, [*LevelRAG*](https://arxiv.org/abs/2502.18139) — a high-level searcher coordinating multiple low-level searchers via query decomposition.
-- Verma et al., 2024, [*Plan\*RAG: Efficient Test-Time Planning for Retrieval Augmented Generation*](https://arxiv.org/abs/2410.20753) (originally circulated as *Plan×RAG: Planning-guided Retrieval Augmented Generation*) — matches the plan-then-retrieve paradigm.
-- Work on question decomposition with cross-encoder re-ranking further supports staged, planned retrieval.
-
-For Cake: make the retrieval plan an explicit data structure in the pipeline rather than hidden prompt text, and keep the pipeline modular enough to add a planner stage later. Eventually, advanced users could supply simple planners (in Elixir) that choose retrieval strategy by question type.
-
----
+- [x] The per-turn flow is an explicit staged pipeline: decompose → search → select → prompt → generate → cite (`Conversation.run_turn/2`; #140, #141)
+- [x] Structured JSON completion callback for machine-readable LLM outputs (`Generation.complete_json/3`; #234)
+- [ ] Stock reasoning templates (evidence extraction, compare-and-contrast) with intermediate steps logged for analysis, hidden from end users
+- [ ] Multi-stage retrieval planning with the plan as an explicit data structure and iterative retrieval — decomposition today is single-shot, one fan-out per turn
 
 ## 5. Guardrails and Faithfulness
 
-This area covers preventing and detecting hallucinations and unfaithful answers — critical in enterprise settings, where a plausible-sounding but wrong answer carries real cost.
+Preventing and detecting unfaithful answers; enterprise adoption requires a trust story of faithfulness checks, citation quality, and monitored hallucination rates.
 
-**Relevance to Cake.** Enterprise adoption requires a credible trust story: faithfulness checks, citation quality, and monitoring of hallucination rates over time.
+References: [Tamber et al. 2025](https://arxiv.org/abs/2505.04847) (FaithJudge), [Wallat et al. 2024](https://arxiv.org/abs/2412.18004) (correctness ≠ faithfulness), [Sok et al. 2025](https://arxiv.org/abs/2509.09360) (MetaRAG metamorphic testing), [CiteFix](https://arxiv.org/abs/2504.15629), [RAGE toolkit](https://aclanthology.org/2024.konvens-main.6/) (citation metrics).
 
-### 5.1 Faithfulness Checks
-
-**What it is.** Post-hoc or in-loop verification that an answer is supported by the retrieved context: NLI-style entailment models, LLM-as-judge scoring, or metamorphic tests (perturb the inputs and check that the answer changes sensibly).
-
-**Benefits**
-
-- Catches egregious hallucinations.
-- Can emit confidence scores or route answers to human review.
-
-**Trade-offs**
-
-- Additional models and cost.
-- Judgments are noisy, particularly across domains.
-
-**Mitigations**
-
-- Use binary safe/unsafe thresholds rather than assuming precise calibration is achievable.
-- Start with LLM-as-judge using a simple faithful/unfaithful prompt against the citations.
-- Reserve heavier checks for high-risk tenants and queries.
-
-**Relevant work**
-
-- Tamber et al. (Vectara), 2025, [*Benchmarking LLM Faithfulness in RAG with Evolving Leaderboards*](https://arxiv.org/abs/2505.04847) (EMNLP 2025 Industry) — introduces the FaithJudge framework and [hallucination leaderboard](https://github.com/vectara/FaithJudge) for LLM-as-judge faithfulness evaluation.
-- Wallat et al., 2024, [*Correctness is not Faithfulness in RAG Attributions*](https://arxiv.org/abs/2412.18004) — demonstrates that a correct citation is insufficient; the citation must actually ground the answer.
-- Sok et al., 2025, [*MetaRAG: Metamorphic Testing for Hallucination Detection in RAG Systems*](https://arxiv.org/abs/2509.09360) — a metamorphic testing framework for hallucination detection in production RAG systems where gold labels are unavailable.
-
-For Cake: short term, a simple faithfulness scorer using LLM-as-judge over the retrieved context; longer term, metamorphic tests integrated into the evaluation suite.
-
-### 5.2 Citation Mode
-
-**What it is.** Require the model to emit inline citations tied to retrieved chunks (e.g. `[1]`, `[2]`), mapped to document IDs and URLs.
-
-**Benefits**
-
-- Increases user trust.
-- Enables automated evaluation of citation correctness and faithfulness.
-- Encourages more grounded responses.
-
-**Trade-offs**
-
-- Models can mis-attribute citations.
-- Formatting is fiddly and the UX must accommodate it.
-
-**Mitigations**
-
-- Post-process citations (in the style of CiteFix) rather than trusting raw model output.
-- Evaluate citation correctness; repair or drop incorrect citations.
-
-**Relevant work**
-
-- Maheshwari et al., 2025, [*CiteFix: Enhancing RAG Accuracy Through Post-Processing Citation Correction*](https://arxiv.org/abs/2504.15629) (ACL 2025 Industry) — post-processing that improves citation accuracy at minimal cost.
-- Penzkofer and Baumann, 2024, [*Evaluating and Fine-Tuning Retrieval-Augmented Language Models to Generate Text with Accurate Citations*](https://aclanthology.org/2024.konvens-main.6/) (KONVENS 2024; the RAGE toolkit) — citation precision/recall metrics for evaluating and tuning RAG systems.
-
-For Cake: make citations mandatory for factual QA modes; build a generic citation data model (`chunk_id`, `char_span`, `doc_url`); and let tenant UIs style citations as they see fit.
-
----
+- [x] Inline `[N]` citations parsed from responses, resolved against the chunk map, deduplicated, ordered (`Cake.Citations`, `Cake.Responses`; #67)
+- [x] Hallucinated citation markers (indices with no backing chunk) filtered out in post-processing (`Cake.Citations`)
+- [x] Generic citation data model — exactly `id`, `label`, `source_ref`, `preview`, `extras` — per retrievable type (`Cake.Citable` protocol)
+- [ ] **(priority)** Basic answer/citation logging for offline inspection: which chunks retrieved, which cited, per turn
+- [ ] LLM-as-judge faithfulness scorer over answer + retrieved context, binary safe/unsafe thresholds
+- [ ] Citation-correctness evaluation and repair (CiteFix-style post-processing)
+- [ ] Metamorphic tests in the evaluation suite
 
 ## 6. Structured and Domain-Aware Retrieval
 
-This area moves beyond treating documents as bags of words, exploiting schemas, graphs, and domain structure: tables, APIs, CRM objects, product hierarchies, and knowledge graphs.
+Beyond documents-as-bags-of-words: schemas, graphs, and domain structure as retrieval sources.
 
-**Relevance to Cake.** This is where Cake can evolve from "RAG framework" toward "RAG substrate for enterprise systems". Enterprises already have schemas and graphs; Cake needs to plug into them.
+References: [Cheerla 2025](https://arxiv.org/abs/2507.12425) (structured-data RAG), [KG²RAG](https://arxiv.org/abs/2502.06864), [GGR](https://openreview.net/forum?id=R1NWMExESj) (GNN-guided prompting), [Microsoft GraphRAG](https://arxiv.org/abs/2404.16130).
 
-### 6.1 Schema-Aware Retrieval
-
-**What it is.** Use domain schemas (tables, JSON, code, API descriptions) to retrieve structured records rather than only text, embed both text and schema metadata, and let the LLM reason over structured and unstructured evidence together.
-
-**Benefits**
-
-- Better performance when the answer lives in a database or API rather than a document.
-- Reads current data instead of stale document snapshots.
-
-**Trade-offs**
-
-- Requires connectors and schema mapping.
-- Some LLMs handle complex structured prompts poorly.
-
-**Mitigations**
-
-- Combine structured queries (SQL, filters) with text search.
-- Summarise structured outputs into LLM-friendly snippets.
-
-**Relevant work.** Cheerla, 2025, [*Advancing Retrieval-Augmented Generation for Structured Enterprise and Internal Data*](https://arxiv.org/abs/2507.12425) — hybrid retrieval combining BM25, dense retrieval, and metadata-aware filtering over structured data. For Cake: define a schema ingestion interface so that, given a table or API, Cake can build metadata-aware filters and join structured results with text context.
-
-### 6.2 Graph-Augmented Retrieval
-
-**What it is.** Use a knowledge graph — pre-existing or derived from text — to expand retrieval via neighbours, organise context around entity and relationship paths, and guide multi-hop reasoning.
-
-**Benefits**
-
-- Better coverage of related facts.
-- More coherent long-form answers.
-- Particularly effective in complex domains (biomedical, legal, enterprise organisations).
-
-**Trade-offs**
-
-- Building and maintaining knowledge graphs is expensive.
-- Graph operations add latency.
-- The graph must be kept in sync with the underlying text.
-
-**Mitigations**
-
-- Generate a lightweight graph from documents (entities plus document IDs).
-- Link chunks to graph nodes.
-- Engage the graph selectively, for multi-hop and cross-document query types.
-
-**Relevant work**
-
-- Zhu et al., 2025, [*KG²RAG*](https://arxiv.org/abs/2502.06864) — semantic retrieval, then knowledge-graph-guided expansion and organisation into paragraphs for RAG.
-- Liu et al., 2025, [*Knowledge Graph Retrieval-Augmented Generation via GNN-Guided Prompting*](https://openreview.net/forum?id=R1NWMExESj) (GGR) — GNN-guided KG-RAG that preserves key reasoning paths.
-- Edge et al., 2024, [*From Local to Global: A Graph RAG Approach to Query-Focused Summarization*](https://arxiv.org/abs/2404.16130) (Microsoft GraphRAG) and related enterprise deployments report substantial gains on cross-document reasoning.
-
-For Cake: do not attempt full GraphRAG in v1. Instead, provide hooks for tenants who already have graphs, and offer a basic document-derived graph (entities, document IDs, links).
-
-### 6.3 Vocabulary Steering
-
-**What it is.** Use logit bias or vocabulary steering so the model prefers domain-specific terms present in the context and avoids generic substitutions (e.g. "employee handbook" rather than "staff manual").
-
-**Benefits**
-
-- More consistent terminology.
-- Less generic, hallucination-prone phrasing.
-- Useful for brand names, product names, and internal acronyms.
-
-**Trade-offs**
-
-- Logit bias APIs are model-specific.
-- Misconfiguration can produce degenerate output.
-
-**Mitigations**
-
-- Apply bias only to a small, curated term list per tenant.
-- Keep bias magnitudes modest and test thoroughly.
-
-**Relevant work.** This is established practice rather than formal research; enterprise RAG whitepapers describe vocabulary steering for brand-safe output. For Cake: offer a preferred-vocabulary configuration at tenant level, and later auto-suggest vocabulary lists from the tenant's corpus.
-
----
+- [ ] Schema ingestion interface: metadata-aware filters from a table/API definition, joining structured results with text context
+- [ ] Graph hooks for tenants with existing knowledge graphs
+- [ ] Basic document-derived entity graph (entities + document IDs + links)
+- [ ] Preferred-vocabulary configuration (logit bias over a small curated term list)
 
 ## 7. Conversational Memory
 
-Multi-turn RAG requires tracking what has been said, what has been retrieved, and what the user cares about over time.
+Multi-turn RAG: tracking what has been said, retrieved, and decided. A conversation is a stateful process — a natural fit for Elixir/OTP.
 
-**Relevance to Cake.** Cake's Elixir/OTP foundations suit this naturally: a conversation is a stateful process, not a stateless question-answer exchange. This is an area where Cake can outperform.
+References: [MTRAG](https://arxiv.org/abs/2501.03468) (multi-turn benchmark), [Wu et al. 2025](https://arxiv.org/abs/2504.15965) (memory-mechanisms survey).
 
-### 7.1 Conversation-Aware Retrieval
-
-**What it is.** Embed conversation turns and use them as additional retrieval signals (the conversation has been about VPNs, not HR) and to disambiguate pronouns and references. This constitutes the conversation's short-term memory.
-
-**Benefits**
-
-- Better contextual relevance.
-- Fewer repeated clarification requests.
-
-**Trade-offs**
-
-- Memory grows over time, and retrieval over it becomes expensive.
-- Risk of retrieving outdated context, such as superseded answers.
-
-**Mitigations**
-
-- Bound short-term memory: the last N turns plus a running summary.
-- Summarise older turns.
-
-**Relevant work.** Surveys of memory architectures in LLM systems (e.g. Wu et al., 2025, [*From Human Memory to AI Memory*](https://arxiv.org/abs/2504.15965)) and multi-turn benchmarks such as [MTRAG](https://arxiv.org/abs/2501.03468) evaluate multi-turn retrieval and reasoning directly. For Cake: provide a built-in conversation memory store and retrieval hook, separate from the main knowledge base, with tenant-tunable memory length and summarisation strategy.
-
-### 7.2 Long-Term Memory
-
-**What it is.** Persist distilled facts about the user or an ongoing task — preferences, company-specific decisions, prior agreements — as structured objects or summarised notes.
-
-**Benefits**
-
-- Supports long-lived workflows and agents.
-- Avoids re-asking questions already answered.
-
-**Trade-offs**
-
-- Risk of persisting incorrect information.
-- Stored facts can conflict with newer knowledge-base content.
-
-**Mitigations**
-
-- Attach timestamps and confidence levels to stored facts.
-- Periodically reconcile memory against authoritative sources.
-
-**Relevant work.** Long-term memory is covered by conversational memory surveys and multi-turn RAG evaluation work. For Cake: offer a long-term memory interface — a simple key-value or fact-graph store, with LLM helpers that update it conservatively.
-
-### 7.3 Multi-Turn Reference Disambiguation
-
-**What it is.** Resolve pronouns and shorthand across turns: "that policy" → which policy? "the second option you mentioned" → which chunk or document?
-
-**Benefits**
-
-- Critical for enterprise conversational UX.
-- Reduces misinterpretation.
-
-**Trade-offs**
-
-- Requires either LLM-based resolution over recent turns or a graph of mentions and their bindings.
-
-**Mitigations**
-
-- Use a small coreference resolver over recent turns.
-- Use retrieval over conversation memory to find the most recently discussed entity.
-
-**Relevant work.** Multi-turn benchmarks such as [MTRAG](https://arxiv.org/abs/2501.03468) (Katsis et al., 2025) centre on QA where context tracking is essential. For Cake: make reference resolution an explicit pipeline step that rewrites the raw user query into a fully de-referenced query.
-
----
+- [x] Conversation as a stateful process: GenServer with a turn state machine, message history, accumulated citations and errors (`Cake.Conversation` + `Conversation.State`; #138–#141)
+- [x] Follow-up turns reuse cached retrieval results instead of re-searching (`Cake.Conversation`)
+- [x] Manual-selection mode: retrieve candidates, let the user choose documents, then generate (`manualask/2` + `select_docs/2`; #143)
+- [ ] Conversation memory store and retrieval hook separate from the main KB, bounded (last N turns + summary)
+- [ ] Long-term memory interface: timestamped, confidence-scored facts with cautious LLM-mediated updates
+- [ ] Reference-resolution pipeline step: rewrite the raw query into a de-referenced query before retrieval
 
 ## 8. Evaluation and Feedback Loops
 
-Evaluation cannot be an afterthought. Production RAG requires constant measurement of retrieval quality, generation faithfulness, and drift over time.
+Constant measurement of retrieval quality, generation faithfulness, and drift. First-class evaluation tooling is a differentiator.
 
-**Relevance to Cake.** First-class RAG evaluation tooling is a major potential differentiator, against the status quo of ad-hoc dashboards assembled per deployment.
+References: [ARES](https://aclanthology.org/2024.naacl-long.20/) (synthetic queries + LLM judges), [FRAMES](https://arxiv.org/abs/2409.12941) (factuality/retrieval/reasoning benchmark), [Rahmani et al. 2024](https://arxiv.org/abs/2405.07767) (synthetic test collections).
 
-### 8.1 Synthetic Query Evaluation
+- [x] Item-level ingestion failures persisted with pipeline provenance and retried via sweep (`FailedIngest`, `Pipelines.detuple_with_logging/3`, `sweep/5`; #72, #76, #77)
+- [x] Per-result retrieval provenance: search conditions, backend and CAKE scores, decomposition traceability (`Search.Result`, `Search.Provenance`; #154, #238)
+- [ ] **(priority)** Synthetic evaluation kit: generate queries + answers from a corpus, run them through pipelines, report recall/precision/faithfulness
+- [ ] Human-validated subset mixed into synthetic eval sets
+- [ ] Drift KPIs with alerting on deltas: context recall, answer faithfulness, user feedback rates
+- [ ] Multi-turn evaluation (MTRAG-style) over conversation flows
 
-**What it is.** Use LLMs to generate synthetic queries, answers, and sometimes labels from the corpus, then evaluate retrieval and generation performance against them.
+## Design Groundwork
 
-**Benefits**
+Structural decisions that keep the above buildable without rework.
 
-- Builds evaluation sets cheaply, without full human labelling.
-- Enables rapid comparison of chunking and retrieval configurations.
-- Supports automated acceptance checks before deploying changes.
+- [x] Pipelines are first-class: behaviour contracts per GDS, result tuples at every step, shared error-handling infrastructure (`Cake.Pipelines`, `Books.Pipeline`, `Documents.Pipeline`)
+- [x] Search layer decoupled from ingestion contexts via `:search_collections` config; boundaries compiler-enforced (#192, #214)
+- [x] Collaborator modules injected as opts/config for Mox substitution throughout (embeddings, generation, responses, decomposition, backend)
+- [ ] Declarative pipeline configuration (YAML/JSON) so retrieval recipes are config, not code
+- [ ] OpenSearch document schema extended for multiple vector fields per chunk (raw, summary, entities)
+- [ ] Conversation memory split into its own index/store with a clean API boundary to corpus retrieval
+- [ ] Tenant concept: per-tenant indices, retrieval recipes, and configuration — today the app is single-endpoint with fixed collection names
 
-**Trade-offs**
+## Reach Goals
 
-- Synthetic queries may not match the real user distribution.
-- LLM-generated answers can be wrong, polluting the labels.
+Directions too open-ended to be checklist items yet — candidates for promotion once scoped.
 
-**Mitigations**
-
-- Mix in a small human-validated subset.
-- Use LLM-as-judge for scoring, not as ground truth.
-
-**Relevant work**
-
-- Saad-Falcon et al., 2024, [*ARES: An Automated Evaluation Framework for Retrieval-Augmented Generation Systems*](https://aclanthology.org/2024.naacl-long.20/) (NAACL 2024) — automated RAG evaluation using synthetic queries and LLM judges.
-- Krishna et al., 2024, [*Fact, Fetch, and Reason: A Unified Evaluation of Retrieval-Augmented Generation*](https://arxiv.org/abs/2409.12941) (the FRAMES benchmark) — a unified dataset for evaluating factuality, retrieval, and reasoning in RAG.
-- Rahmani et al., 2024, [*Synthetic Test Collections for Retrieval Evaluation*](https://arxiv.org/abs/2405.07767) (SIGIR 2024) — fully synthetic IR benchmarks built with LLMs.
-
-For Cake: build a synthetic evaluation kit — given a corpus, auto-generate 100–500 synthetic queries and answers, run them through different Cake pipelines, and report recall, precision, and faithfulness metrics.
-
-### 8.2 Drift Detection
-
-**What it is.** Monitor change over time: *data drift* (new documents, updated policies), *concept drift* (query meanings shift), and *model drift* (new model versions behave differently).
-
-**Benefits**
-
-- Prevents silent degradation.
-- Gives enterprises confidence that failures will be detected.
-
-**Trade-offs**
-
-- Non-trivial to implement, and the metrics can be fuzzy.
-- Requires historical logs, not just snapshots.
-
-**Mitigations**
-
-- Track simple KPIs: context recall, answer faithfulness, user feedback rates.
-- Alert on significant deltas.
-
-**Relevant work.** Industry material on retrieval drift monitoring and concept-drift adaptation, and RAG evaluation literature emphasising continuous monitoring in production. For Cake: incorporate drift dashboards at the framework level — per corpus, per tenant, and before/after model version changes.
-
----
-
-## Recommendations
-
-This section translates the survey into practice: what to build now, what to adjust in the MVP design, and where Cake can establish an early edge.
-
-### A. Immediate Priorities
-
-1. **Lock in retrieval as a configurable pipeline.**
-   - Implement hybrid retrieval in OpenSearch: BM25 + dense, or neural sparse + dense, with tunable weights.
-   - Add a simple re-ranker, starting with a small cross-encoder on CPU or inexpensive GPU.
-   - Add optional query expansion, starting with HyDE-style hypothetical-answer embedding.
-
-2. **Chunking v1.5: metadata-aware, with overlap.**
-   - Implement metadata-aware semantic chunking using headings and sections where available.
-   - Support configurable overlap per index.
-   - Store basic metadata: `doc_id`, `section_title`, `page`, and similar fields.
-
-3. **Context builder abstraction.**
-   - Extract a formal `ContextBuilder` from the current pipeline: deduplicate hits, group by document, attach metadata and roles.
-   - Provide two strategies initially: simple top-k raw chunks, and grouped-by-document with basic summarisation.
-
-4. **Citations and logging.**
-   - Add a mandatory citation mode for factual QA paths.
-   - Log retrieved chunk IDs, citations used, and basic LLM-as-judge faithfulness scores.
-
-5. **Basic evaluation harness.**
-   - Implement a small ARES-inspired workflow: synthetic queries generated from the corpus, scored for relevance and faithfulness by LLM-as-judge.
-
-Together these are enough to position Cake as a serious framework rather than a do-it-yourself assembly of parts.
-
-### B. MVP Design Changes
-
-None of this requires a rewrite, but a few structural decisions matter now:
-
-- **Make pipelines first-class.** Represent retrieval and generation as structured Elixir pipelines — `query_normalize → planner (optional) → retriever(s) → reranker → context_builder → generator → guardrails` — with configurations stored declaratively (YAML/JSON) so tenants can define pipelines without code.
-- **Design the document schema for multi-representation.** Even before it is fully exploited, define the OpenSearch schema to allow multiple vector fields (raw, summary, entities) and rich metadata, avoiding migration pain later.
-- **Split memory from the knowledge base.** Keep conversational memory in a separate index or store from the main corpus, with a clean API boundary between conversation-memory retrieval and corpus retrieval.
-
-### C. Scaling Considerations
-
-For high-touch enterprise implementations, the following matter most:
-
-- **Configurable retrieval recipes.** Each customer will need slightly different hybrid weights, chunking strategy, and re-ranking depth. These must be adjustable in configuration, not code.
-- **Evaluation and monitoring built in.** Shipping with a synthetic evaluation harness, faithfulness scoring, and drift dashboard hooks supports the pitch that Cake does not just build a RAG system but monitors and tunes it over time.
-- **Hooks for structure.** Full graph-augmented retrieval is not needed on day one, but the extension points for graph-based retrieval and for ingesting SQL/NoSQL tables with domain-aware filters should exist early.
-
-### D. Early Differentiators
-
-1. **Multi-representation chunking as a first-class feature.** Most tools still treat a chunk as a single embedding. Cake can define a multi-vector document schema and provide stock pipelines for combining representations — a natural fit for its schema-design and OpenSearch strengths.
-2. **A built-in chunking evaluation lab.** Almost no framework productises Chroma-style chunking evaluation. Cake could let a customer upload a corpus, try three or four chunking configurations, and compare metrics and example queries side by side.
-3. **Conversation-aware enterprise RAG.** Many products still treat every query as stateless. Cake can bake in short-term memory embeddings, basic long-term memory, and multi-turn evaluation in the style of MTRAG — positioning Cake for ongoing knowledge work rather than single questions.
-4. **Evaluation as part of the core story.** Building on ARES and FRAMES, make evaluation part of the standard Cake deployment: the pitch is measurement, not just construction.
-
-### Risks
-
-- **Over-engineering early.** The research directions above (LevelRAG-style planning, graph retrieval, advanced query expansion) are tempting, but the priority is a sellable v1, not a research platform. *Mitigation:* ship hybrid retrieval, re-ranking, semantic chunking, citations, and basic evaluation first; everything else is explicitly Phase 2.
-- **Scope creep through perfectionism.** The MVP does not need to be state-of-the-art across all eight areas to be viable. *Mitigation:* define a hard MVP threshold — hybrid retrieval, semantic chunking, citations, basic synthetic evaluation — and treat anything beyond it as explicit backlog rather than an implicit requirement.
+- Learn per-tenant hybrid fusion weights from minimal user feedback (clicks, ratings)
+- Re-rank chunk groups (whole documents/sections) rather than individual chunks; multi-objective re-ranking (relevance + recency + access control)
+- Graph-aware re-rankers that treat a document and its graph neighbours as one unit
+- Multi-embedding query expansion in a learned semantic space ([Pan et al. 2025](https://www.mdpi.com/2079-9292/14/9/1744)-style), or retrieval-grounded expansion re-scoring ([RFG](https://www.scitepress.org/Link.aspx?doi=10.5220/0013836900004000)-style)
+- A customer-facing chunking evaluation lab: upload a corpus, compare chunking configurations side by side with metrics
+- Published research artifacts: a "Cake Retrieval Study" (neural sparse vs. BM25 hybrids on enterprise corpora) and "Multi-Representation Chunking for Enterprise RAG with OpenSearch"
+- Evolve from RAG framework toward a RAG substrate for enterprise systems, plugging into existing schemas and graphs
+- Position conversation-aware RAG and built-in evaluation as the core product story ("we measure and monitor, not just build")
+- Auto-suggest preferred-vocabulary lists from a tenant's corpus
+- Framework-level drift dashboards per corpus, tenant, and model version

--- a/feature_roadmap.md
+++ b/feature_roadmap.md
@@ -16,6 +16,7 @@ A checklist of RAG capabilities for Cake, organised into eight capability areas 
 - [8. Evaluation and Feedback Loops](#8-evaluation-and-feedback-loops)
 - [Design Groundwork](#design-groundwork)
 - [Reach Goals](#reach-goals)
+- [Further Reading](#further-reading)
 
 ---
 
@@ -153,3 +154,48 @@ Directions too open-ended to be checklist items yet — candidates for promotion
 - Position conversation-aware RAG and built-in evaluation as the core product story ("we measure and monitor, not just build")
 - Auto-suggest preferred-vocabulary lists from a tenant's corpus
 - Framework-level drift dashboards per corpus, tenant, and model version
+
+## Further Reading
+
+A curated shelf of current work worth tracking, grouped by what it means for Cake. These are not roadmap commitments — they are the frontier the roadmap should be steered against. Links verified as of 2026-08.
+
+### Agentic retrieval and learned planning
+
+Where the decompose → retrieve → answer loop is heading: models trained to decide when and what to retrieve, rather than pipelines that hard-code it.
+
+- [**Search-R1: Training LLMs to Reason and Leverage Search Engines with Reinforcement Learning**](https://arxiv.org/abs/2503.09516) (Jin et al., 2025) — RL-trains an LLM to interleave multi-turn search calls inside its reasoning chain, beating standard RAG baselines by 20–41%. The founding paper of the agentic-search-RL line, and the template for what could eventually replace a hand-written decomposition loop like `Cake.Decomposition`.
+- [**Chain-of-Retrieval Augmented Generation (CoRAG)**](https://arxiv.org/abs/2501.14342) (Wang et al., Microsoft Research, 2025; NeurIPS 2025) — trains models to plan chains of retrievals, reformulating the query as evidence accumulates, and studies test-time scaling of retrieval steps. The natural successor to single-shot decomposition.
+- [**Tongyi DeepResearch Technical Report**](https://arxiv.org/abs/2510.24701) (Tongyi Lab, 2025) — the strongest fully open deep-research agent (30.5B MoE), trained end-to-end on synthetic agentic data. The best public blueprint of a production-grade iterative-retrieval stack.
+- [**Recursive Language Models**](https://arxiv.org/abs/2512.24601) (Zhang et al., MIT CSAIL, 2025) — treats a long prompt as an environment the model programmatically inspects, chunks, and recursively calls itself over, handling inputs roughly 100× the context window. Reframes the long-context-vs-RAG debate as "retrieval is recursive inference-time decomposition".
+
+### Retrievers, rankers, and representations
+
+- [**ReasonIR: Training Retrievers for Reasoning Tasks**](https://arxiv.org/abs/2504.20595) (Shao et al., Meta FAIR/UW, 2025) — the first retriever trained specifically for reasoning-intensive queries, via synthetic hard queries and plausible-but-unhelpful hard negatives. Evidence that similarity-trained embedders underperform once queries require inference — relevant to any embedding-model choice.
+- [**Qwen3 Embedding**](https://arxiv.org/abs/2506.05176) (Qwen team, 2025) — the current default open embedding + reranker family (Apache-2.0, instruction-tunable, Matryoshka dimensions); a practical answer to which open models to plug into the dense and re-ranking stages. The follow-up [Qwen3-VL-Embedding and Reranker](https://arxiv.org/abs/2601.04720) (2026) extends the same stack to images, document screenshots, and video in one vector space.
+- [**ColPali: Efficient Document Retrieval with Vision Language Models**](https://arxiv.org/abs/2407.01449) (Faysse et al., ICLR 2025) — OCR-free visual document retrieval: ColBERT-style late interaction over patch embeddings of page images. Directly relevant to PDF-heavy ingestion — retrieval over page images instead of lossy parsed text.
+- [**MUVERA: Multi-Vector Retrieval via Fixed Dimensional Encodings**](https://arxiv.org/abs/2405.19504) (Dhulipala, Jayaram et al., Google Research) — compresses ColBERT/ColPali-style multi-vector sets into single fixed-dimension vectors whose inner product provably approximates MaxSim, making late-interaction retrieval servable on ordinary ANN infrastructure. What makes the ColPali lineage production-feasible.
+- [**Towards Competitive Search Relevance for Inference-Free Learned Sparse Retrievers**](https://arxiv.org/abs/2411.04403) (Geng et al., Amazon OpenSearch neural-sparse team, 2024–25) — document-side-only learned sparse retrieval approaching SPLADE relevance on a plain Lucene inverted index, with zero query-time inference cost. Maximally relevant to Cake's stack: a third hybrid signal that is nearly free at query time.
+- [**Late Chunking: Contextual Chunk Embeddings Using Long-Context Embedding Models**](https://arxiv.org/abs/2409.04701) (Günther et al., Jina AI) — embed the whole document through a long-context encoder first and chunk the token embeddings afterward, so every chunk vector carries document-wide context. The cheapest known fix for the context-stripping problem that page-per-chunk pipelines share.
+
+### Context engineering and long context
+
+- [**Context Rot: How Increasing Input Tokens Impacts LLM Performance**](https://research.trychroma.com/context-rot) (Hong, Troynikov, Huber — Chroma, 2025) — eighteen frontier models degrade non-uniformly with input length, even on trivial tasks, and distractors make it worse. The empirical backbone of "retrieve tightly, don't stuff the window".
+- [**NoLiMa: Long-Context Evaluation Beyond Literal Matching**](https://arxiv.org/abs/2502.05167) (Modarressi et al., ICML 2025) — needle-in-a-haystack with no lexical overlap between needle and question: most models collapse below 50% of their short-context baseline by 32K tokens. Data against the "just use long context instead of retrieval" argument.
+- [**Effective Context Engineering for AI Agents**](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) (Anthropic, 2025) — the post that codified context engineering as a discipline: context as a finite resource, compaction, structured note-taking, just-in-time retrieval, sub-agent architectures. Reframes what a RAG framework's job is once its consumer is an agent rather than a single prompt.
+- [**REFRAG: Rethinking RAG based Decoding**](https://arxiv.org/abs/2509.01092) (Lin et al., Meta, 2025) — feeds precomputed compressed chunk embeddings directly to the decoder, expanding only the chunks an RL policy deems worth full tokens: up to ~30× faster time-to-first-token at matched accuracy. The most credible context-compression result for high-throughput serving.
+- [**DeepSeek-OCR: Contexts Optical Compression**](https://arxiv.org/abs/2510.18234) (DeepSeek-AI, 2025) — a 3B VLM that decodes document pages from ~100 vision tokens at ~97% precision (about 10× compression versus text tokens). State-of-the-art ingestion parsing, and a provocation about whether "chunk as text" is the right substrate at all.
+
+### Evaluation, citations, and memory
+
+- [**Reliability without Validity**](https://arxiv.org/abs/2606.19544) (Norman, 2026) — a systematic evaluation of 21 LLM-as-judge models: agreement metrics overstate discriminative ability, and judge rankings are unstable across datasets. Required reading before wiring an LLM judge into CI as a quality gate (see §8).
+- [**Generation-Time vs. Post-hoc Citation: A Holistic Evaluation of LLM Attribution**](https://arxiv.org/abs/2509.21557) (Saxena et al., 2025) — cite-while-generating versus attribute-after-drafting is a coverage/correctness trade-off, with retrieval quality the dominant driver of attribution quality. Load-bearing for where the citation step sits in Cake's turn pipeline.
+- [**Cited but Not Verified: Parsing and Evaluating Source Attribution in LLM Deep Research Agents**](https://arxiv.org/abs/2605.06635) (Onweller, 2026) — audits deployed research agents and finds 11–57% citation hallucination rates, proposing a three-axis check: link resolves, content relevant, fact supported. A ready-made rubric for end-to-end evaluation of `Citable` output.
+- [**Memory OS of AI Agent**](https://arxiv.org/abs/2506.06326) (Kang et al., 2025) — an OS-inspired three-tier memory manager (short/mid/long-term) with dynamic promotion and eviction; the most-cited post-MemGPT memory design, and a plausible growth path for a long-lived `Conversation` process. Pair with [MemoryAgentBench](https://arxiv.org/abs/2507.05257) (Hu et al., 2025–26), which finds no current memory system masters accurate retrieval, test-time learning, long-range understanding, and selective forgetting at once.
+- [**OP-Bench: Benchmarking Over-Personalization**](https://arxiv.org/abs/2601.13722) (Hu, 2026) — memory-augmented personalization backfires in three measurable patterns: irrelevance, repetition, sycophancy. The failure-mode catalogue to consult before building any per-user memory feature.
+
+### Security and structured data
+
+- [**PoisonedRAG: Knowledge Corruption Attacks to Retrieval-Augmented Generation**](https://arxiv.org/abs/2402.07867) (Zou et al., USENIX Security 2025) — roughly five injected documents in a 2.6M-text corpus steer answers to attacker-chosen outputs with ~97% success. The paper that made "who can write to the index?" a security question every enterprise RAG deployment must answer.
+- [**Architecture Matters: Comparing RAG Systems under Knowledge Base Poisoning**](https://arxiv.org/abs/2605.05632) (Korn, 2026) — poisoning success varies from 81.9% for naive retrieve-and-stuff down to 24.4% for more mediated designs: pipeline architecture is itself a poisoning defense.
+- [**Spider 2.0: Evaluating Language Models on Real-World Enterprise Text-to-SQL Workflows**](https://arxiv.org/abs/2411.07763) (Lei et al., ICLR 2025) — 632 real enterprise workflow problems over 1,000+-column schemas; the best reasoning models solve about a fifth of them. Defines the actual difficulty behind §6's schema-aware retrieval.
+- [**LinearRAG: Linear Graph Retrieval Augmented Generation on Large-scale Corpora**](https://arxiv.org/abs/2510.10114) (Zhuang et al., 2025) — graph RAG without LLM relation extraction: lightweight entity extraction plus semantic linking, with construction cost linear in corpus size. The pragmatic on-ramp for §6's document-derived entity graph.


### PR DESCRIPTION
## Summary

Documentation-audit branch: takes `feature_roadmap.md` from raw-pasted draft to an audited status checklist with a frontier reading list, and applies the first corrections from the codebase-wide documentation audit.

1. **Roadmap: professional rewrite** (`58f2a9b`) — removed the duplicated raw-paste copy, stripped ChatGPT artifacts (`:contentReference[oaicite:…]` markers, broken citation fragments, trailing conversational offer), professionalized tone and headings, fixed structure and ToC. No technical content lost.
2. **Roadmap: verified citation links** (`437754d`) — every citation links to its verified arXiv / ACL Anthology / OpenReview / MDPI / SciTePress / publisher page; several citations corrected (Plan\*RAG retitle, the Pan et al. / "LLM-QE" conflation, *Reconstructing Context:* full title, anonymous mentions resolved to real sources).
3. **Roadmap: checklist rewrite audited against master** (`8fe0c35`) — checkbox roadmap; checked boxes verified against commit history and code (through #241), citing module and landing PR; MVP items tagged **(priority)**; open-ended directions moved to **Reach Goals**.
4. **Roadmap: Further Reading section** (`69db3ca`) — curated cutting-edge work (mid-2025 → 2026-08), links verified against live sources, with commentary tying each entry to its roadmap section.
5. **Merge of master** (`32ba47b`) — brings in #242 (decomposition-traceability property tests).
6. **README struct inventory + CLAUDE.md enumeration rule** (`84b226e`) — from the read-only documentation audit: adds the missing `Cake.Decomposition.Result` row and an Embedded Schemas section (QuestionForm/SelectionForm); corrects the `Conversation.State` collaborator list, the `Search.Provenance` traceability fields, and the `Hexdoc` description (Elixir source cloned from elixir-lang/elixir, not HTML from hex.pm). CLAUDE.md's enumeration rule now requires every new issue to end with a documentation-update checkbox covering new structs.

## Notes for review

- The checklist audit deliberately distinguishes near-misses: PDF chunking is checked only for *metadata* (page-per-chunk, no overlap); decomposition is checked as *single-shot*.
- Docs-only changes throughout; no code touched, quality gates unaffected.
- **Flagged, not fixed:** README's Layer-3/roadmap prose still describes query decomposition as "planned but not yet implemented" — deliberately deferred at the maintainer's request until the decomposition feature is finished. The full stale-line list (11 locations) is in the audit report, along with two latent code defects found via doc mismatches (`index_document/3`'s unreachable success path; the Books sweep version filter mismatch) — left untouched per the known-defect-adjacency rule.